### PR TITLE
feat: GAD-7 Questionnaire Implementation

### DIFF
--- a/fsh-generated/includes/menu.xml
+++ b/fsh-generated/includes/menu.xml
@@ -69,6 +69,9 @@
         <a href="phq-9.html">PHQ-9</a>
       </li>
       <li>
+        <a href="gad-7.html">GAD-7</a>
+      </li>
+      <li>
         <a href="eq-5d-5l.html">EQ-5D-5L</a>
       </li>
       <li>

--- a/fsh-generated/resources/Bundle-mii-exa-pro-gad-7-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-gad-7-bundle.json
@@ -1,0 +1,1533 @@
+{
+  "resourceType": "Bundle",
+  "id": "mii-exa-pro-gad-7-bundle",
+  "entry": [
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Questionnaire/mii-qst-pro-gad-7"
+      },
+      "fullUrl": "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7",
+      "resource": {
+        "resourceType": "Questionnaire",
+        "id": "mii-qst-pro-gad-7",
+        "meta": {
+          "profile": [
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.2.0"
+          ]
+        },
+        "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7",
+        "title": "MII QST PRO GAD-7",
+        "description": "Generalized Anxiety Disorder Scale-7 (GAD-7)",
+        "code": [
+          {
+            "code": "69737-5",
+            "system": "http://loinc.org",
+            "display": "Generalized anxiety disorder 7 item (GAD-7)"
+          },
+          {
+            "code": "phq-gad7",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-questionnaire-catalogue",
+            "display": "GAD-7 Questionnaire"
+          }
+        ],
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "displayable",
+                "valueBoolean": true
+              },
+              {
+                "url": "collectable",
+                "valueBoolean": true
+              },
+              {
+                "url": "populatable",
+                "valueBoolean": true
+              },
+              {
+                "url": "calculatable",
+                "valueBoolean": true
+              },
+              {
+                "url": "extractable",
+                "valueBoolean": true
+              },
+              {
+                "url": "domainAligned",
+                "valueBoolean": true
+              }
+            ],
+            "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-questionnaire-capabilities"
+          },
+          {
+            "valueExpression": {
+              "name": "rawScore",
+              "language": "text/fhirpath",
+              "expression": "%resource.item.where(linkId.matches('^phq-gad7-q0[1-7]$')).answer.value.ordinal().sum()"
+            },
+            "url": "http://hl7.org/fhir/StructureDefinition/variable"
+          }
+        ],
+        "item": [
+          {
+            "linkId": "GAD-7.Description",
+            "type": "display",
+            "text": "Over the last two weeks, how often have you been bothered by the following problems?",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Wie oft fühlten Sie sich im Verlauf der letzten 2 Wochen durch die folgenden Beschwerden beeinträchtigt?"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "69725-0",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q01').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q01",
+            "type": "choice",
+            "prefix": "1",
+            "text": "Feeling nervous, anxious, or on edge",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Nervosität, Ängstlichkeit oder Anspannung"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "68509-9",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q02').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q02",
+            "type": "choice",
+            "prefix": "2",
+            "text": "Not being able to stop or control worrying",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Nicht in der Lage sein, Sorgen zu stoppen oder zu kontrollieren"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "69733-4",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q03').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q03",
+            "type": "choice",
+            "prefix": "3",
+            "text": "Worrying too much about different things",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Übermäßige Sorgen bezüglich verschiedener Angelegenheiten"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "69734-2",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q04').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q04",
+            "type": "choice",
+            "prefix": "4",
+            "text": "Trouble relaxing",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Schwierigkeiten, sich zu entspannen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "69735-9",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q05').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q05",
+            "type": "choice",
+            "prefix": "5",
+            "text": "Being so restless that it is hard to sit still",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Rastlosigkeit, so dass Stillsitzen schwer fällt"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "69689-8",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q06').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q06",
+            "type": "choice",
+            "prefix": "6",
+            "text": "Becoming easily annoyed or irritable",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Schnelle Verärgerung oder Gereiztheit"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "69736-7",
+                "system": "http://loinc.org"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "language": "text/fhirpath",
+                  "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q07').answer.value, {})"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+              }
+            ],
+            "answerOption": [
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6568-5",
+                  "display": "Not at all",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Überhaupt nicht"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 0
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6569-3",
+                  "display": "Several days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An einzelnen Tagen"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 1
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6570-1",
+                  "display": "More than half the days",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "An mehr als der Hälfte der Tage"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 2
+                  }
+                ]
+              },
+              {
+                "valueCoding": {
+                  "system": "http://loinc.org",
+                  "code": "LA6571-9",
+                  "display": "Nearly every day",
+                  "_display": {
+                    "extension": [
+                      {
+                        "extension": [
+                          {
+                            "url": "lang",
+                            "valueCode": "de"
+                          },
+                          {
+                            "url": "content",
+                            "valueString": "Beinahe jeden Tag"
+                          }
+                        ],
+                        "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                      }
+                    ]
+                  }
+                },
+                "extension": [
+                  {
+                    "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+                    "valueDecimal": 3
+                  }
+                ]
+              }
+            ],
+            "linkId": "phq-gad7-q07",
+            "type": "choice",
+            "prefix": "7",
+            "text": "Feeling afraid, as if something awful might happen",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Gefühl der Angst, so als würde etwas Schlimmes passieren"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "70274-6",
+                "system": "http://loinc.org",
+                "display": "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "name": "Scoreberechnung",
+                  "language": "text/fhirpath",
+                  "expression": "%rawScore"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
+              },
+              {
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                "valueBoolean": true
+              },
+              {
+                "valueCoding": {
+                  "system": "http://unitsofmeasure.org",
+                  "code": "{score}"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                      "code": "survey"
+                    }
+                  ]
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observation-extract-category"
+              }
+            ],
+            "linkId": "phq-gad7-score-total",
+            "type": "decimal",
+            "prefix": "Auswertung",
+            "readOnly": true,
+            "text": "GAD-7 Total Score",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "GAD-7 Gesamtwert"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          {
+            "code": [
+              {
+                "code": "77862-1",
+                "system": "http://loinc.org",
+                "display": "PROMIS emotional distress - anxiety - version 1.0 Tscore"
+              }
+            ],
+            "extension": [
+              {
+                "valueExpression": {
+                  "name": "promis-anxiety-tscore-mapping",
+                  "language": "text/fhirpath",
+                  "expression": "iif(%rawScore = 0, 33.8, iif(%rawScore = 1, 40.3, iif(%rawScore = 2, 44.0, iif(%rawScore = 3, 46.8, iif(%rawScore = 4, 49.2, iif(%rawScore = 5, 51.3, iif(%rawScore = 6, 53.2, iif(%rawScore = 7, 54.9, iif(%rawScore = 8, 56.6, iif(%rawScore = 9, 58.1, iif(%rawScore = 10, 59.6, iif(%rawScore = 11, 61.0, iif(%rawScore = 12, 62.3, iif(%rawScore = 13, 63.5, iif(%rawScore = 14, 64.8, iif(%rawScore = 15, 66.0, iif(%rawScore = 16, 67.2, iif(%rawScore = 17, 68.5, iif(%rawScore = 18, 69.8, iif(%rawScore = 19, 71.2, iif(%rawScore = 20, 72.8, 75.7)))))))))))))))))))))"
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
+              },
+              {
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+                "valueBoolean": true
+              },
+              {
+                "valueCoding": {
+                  "system": "http://unitsofmeasure.org",
+                  "code": "{score}"
+                },
+                "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit"
+              },
+              {
+                "valueCodeableConcept": {
+                  "coding": [
+                    {
+                      "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                      "code": "survey"
+                    }
+                  ]
+                },
+                "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observation-extract-category"
+              }
+            ],
+            "linkId": "phq-gad7-promis-tscore",
+            "type": "decimal",
+            "prefix": "T-Score",
+            "readOnly": true,
+            "text": "PROMIS Anxiety T-Score (derived from GAD-7)",
+            "_text": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "PROMIS Angst T-Score (abgeleitet von GAD-7)"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          }
+        ],
+        "version": "2026.2.0",
+        "status": "active",
+        "experimental": true,
+        "language": "en"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "QuestionnaireResponse/mii-exa-pro-gad-7-response"
+      },
+      "fullUrl": "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/QuestionnaireResponse/mii-exa-pro-gad-7-response",
+      "resource": {
+        "resourceType": "QuestionnaireResponse",
+        "id": "mii-exa-pro-gad-7-response",
+        "meta": {
+          "profile": [
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.2.0"
+          ]
+        },
+        "item": [
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6570-1",
+                  "system": "http://loinc.org",
+                  "display": "More than half the days"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q01"
+          },
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6571-9",
+                  "system": "http://loinc.org",
+                  "display": "Nearly every day"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q02"
+          },
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6570-1",
+                  "system": "http://loinc.org",
+                  "display": "More than half the days"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q03"
+          },
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6569-3",
+                  "system": "http://loinc.org",
+                  "display": "Several days"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q04"
+          },
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6570-1",
+                  "system": "http://loinc.org",
+                  "display": "More than half the days"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q05"
+          },
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6569-3",
+                  "system": "http://loinc.org",
+                  "display": "Several days"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q06"
+          },
+          {
+            "answer": [
+              {
+                "valueCoding": {
+                  "code": "LA6570-1",
+                  "system": "http://loinc.org",
+                  "display": "More than half the days"
+                }
+              }
+            ],
+            "linkId": "phq-gad7-q07"
+          },
+          {
+            "answer": [
+              {
+                "valueDecimal": 13
+              }
+            ],
+            "linkId": "phq-gad7-score-total"
+          },
+          {
+            "answer": [
+              {
+                "valueDecimal": 63.5
+              }
+            ],
+            "linkId": "phq-gad7-promis-tscore"
+          }
+        ],
+        "status": "completed",
+        "language": "de",
+        "subject": {
+          "reference": "Patient/mii-exa-pro-patient"
+        },
+        "authored": "2024-03-15T10:30:00Z",
+        "questionnaire": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7"
+      }
+    },
+    {
+      "request": {
+        "method": "PUT",
+        "url": "Observation/mii-exa-pro-gad-7-observation"
+      },
+      "fullUrl": "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Observation/mii-exa-pro-gad-7-observation",
+      "resource": {
+        "resourceType": "Observation",
+        "id": "mii-exa-pro-gad-7-observation",
+        "meta": {
+          "profile": [
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.2.0"
+          ]
+        },
+        "valueQuantity": {
+          "value": 13,
+          "code": "{score}",
+          "unit": "{score}",
+          "system": "http://unitsofmeasure.org"
+        },
+        "status": "final",
+        "subject": {
+          "reference": "Patient/mii-exa-pro-patient"
+        },
+        "effectiveDateTime": "2024-03-15T10:30:00Z",
+        "code": {
+          "coding": [
+            {
+              "code": "70274-6",
+              "system": "http://loinc.org",
+              "display": "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "mii-exa-pro-patient",
+        "active": true,
+        "name": [
+          {
+            "family": "Example",
+            "given": [
+              "Patient"
+            ]
+          }
+        ],
+        "gender": "other"
+      },
+      "request": {
+        "method": "PUT",
+        "url": "Patient/mii-exa-pro-patient"
+      },
+      "fullUrl": "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Patient/mii-exa-pro-patient"
+    }
+  ],
+  "type": "transaction"
+}

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-questionnaire-catalogue.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-questionnaire-catalogue.json
@@ -13,6 +13,10 @@
       "display": "EuroQol EQ-5D-5L Questionnaire"
     },
     {
+      "code": "phq-gad7",
+      "display": "GAD-7 Questionnaire"
+    },
+    {
       "code": "phq-phq9",
       "display": "PHQ-9 Questionnaire"
     },
@@ -66,5 +70,5 @@
     }
   ],
   "version": "2026.2.0",
-  "count": 14
+  "count": 15
 }

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-score-catalogue.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-score-catalogue.json
@@ -21,6 +21,14 @@
       "display": "EuroQol EQ-5D-5L Profile"
     },
     {
+      "code": "phq-gad7-total",
+      "display": "GAD-7 Total Score"
+    },
+    {
+      "code": "phq-gad7-promis-anxiety-tscore",
+      "display": "GAD-7 derived PROMIS Anxiety T-Score"
+    },
+    {
       "code": "phq-phq9-total",
       "display": "PHQ-9 Total Score"
     },
@@ -166,5 +174,5 @@
     }
   ],
   "version": "2026.2.0",
-  "count": 39
+  "count": 41
 }

--- a/fsh-generated/resources/ImplementationGuide-mii-ig-pro.json
+++ b/fsh-generated/resources/ImplementationGuide-mii-ig-pro.json
@@ -436,6 +436,28 @@
       },
       {
         "reference": {
+          "reference": "Observation/mii-exa-pro-gad-7-observation"
+        },
+        "name": "GAD-7 Observation Example",
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance"
+      },
+      {
+        "reference": {
+          "reference": "QuestionnaireResponse/mii-exa-pro-gad-7-response"
+        },
+        "name": "GAD-7 Questionnaire Response Example",
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response"
+      },
+      {
+        "reference": {
+          "reference": "Bundle/mii-exa-pro-gad-7-bundle"
+        },
+        "name": "GAD-7 Transaction Bundle Example",
+        "description": "Transaction bundle containing GAD-7 questionnaire, response, and derived observation",
+        "exampleBoolean": true
+      },
+      {
+        "reference": {
           "reference": "CapabilityStatement/mii-cps-pro-capabilitystatement"
         },
         "name": "MII CPS PRO CapabilityStatement",
@@ -724,6 +746,14 @@
       },
       {
         "reference": {
+          "reference": "ObservationDefinition/mii-obsdef-pro-score-gad-7"
+        },
+        "name": "MII ObsDef PRO Score GAD-7",
+        "description": "Generalized Anxiety Disorder Scale-7 (GAD-7)",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "ObservationDefinition/mii-obsdef-pro-score-phq-9"
         },
         "name": "MII ObsDef PRO Score PHQ-9",
@@ -984,6 +1014,14 @@
         },
         "name": "MII QST PRO EQ-5D-5L Collectable",
         "description": "MII QST PRO EuroQol Five Dimension Five Level (EQ-5D-5L) Questionnaire - Collectable Version",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "Questionnaire/mii-qst-pro-gad-7"
+        },
+        "name": "MII QST PRO GAD-7",
+        "description": "Generalized Anxiety Disorder Scale-7 (GAD-7)",
         "exampleBoolean": false
       },
       {
@@ -1394,6 +1432,11 @@
             {
               "nameUrl": "phq-9.html",
               "title": "PHQ-9",
+              "generation": "markdown"
+            },
+            {
+              "nameUrl": "gad-7.html",
+              "title": "GAD-7",
               "generation": "markdown"
             },
             {

--- a/fsh-generated/resources/Observation-mii-exa-pro-gad-7-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-gad-7-observation.json
@@ -1,0 +1,29 @@
+{
+  "resourceType": "Observation",
+  "id": "mii-exa-pro-gad-7-observation",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.2.0"
+    ]
+  },
+  "valueQuantity": {
+    "value": 13,
+    "code": "{score}",
+    "unit": "{score}",
+    "system": "http://unitsofmeasure.org"
+  },
+  "status": "final",
+  "subject": {
+    "reference": "Patient/mii-exa-pro-patient"
+  },
+  "effectiveDateTime": "2024-03-15T10:30:00Z",
+  "code": {
+    "coding": [
+      {
+        "code": "70274-6",
+        "system": "http://loinc.org",
+        "display": "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+      }
+    ]
+  }
+}

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-gad-7.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-gad-7.json
@@ -1,0 +1,84 @@
+{
+  "resourceType": "ObservationDefinition",
+  "id": "mii-obsdef-pro-score-gad-7",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.2.0"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
+      "valueString": "2026.2.0"
+    }
+  ],
+  "category": [
+    {
+      "coding": [
+        {
+          "code": "survey",
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+        }
+      ]
+    }
+  ],
+  "permittedDataType": [
+    "Quantity"
+  ],
+  "quantitativeDetails": {
+    "unit": {
+      "coding": [
+        {
+          "code": "1",
+          "system": "http://unitsofmeasure.org"
+        }
+      ]
+    },
+    "decimalPrecision": 0
+  },
+  "qualifiedInterval": [
+    {
+      "range": {
+        "high": {
+          "value": 21
+        },
+        "low": {
+          "value": 0
+        },
+        "extension": [
+          {
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+                  "code": "decrease"
+                }
+              ]
+            },
+            "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-score-score-health-correlation"
+          }
+        ]
+      },
+      "category": "absolute"
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "code": "70274-6",
+        "system": "http://loinc.org",
+        "display": "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+      }
+    ]
+  },
+  "multipleResultsAllowed": false,
+  "method": {
+    "coding": [
+      {
+        "code": "69737-5",
+        "system": "http://loinc.org",
+        "display": "Generalized anxiety disorder 7 item (GAD-7)"
+      }
+    ]
+  }
+}

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-gad-7.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-gad-7.json
@@ -1,0 +1,1337 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "mii-qst-pro-gad-7",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.2.0"
+    ]
+  },
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7",
+  "title": "MII QST PRO GAD-7",
+  "description": "Generalized Anxiety Disorder Scale-7 (GAD-7)",
+  "code": [
+    {
+      "code": "69737-5",
+      "system": "http://loinc.org",
+      "display": "Generalized anxiety disorder 7 item (GAD-7)"
+    },
+    {
+      "code": "phq-gad7",
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-questionnaire-catalogue",
+      "display": "GAD-7 Questionnaire"
+    }
+  ],
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "displayable",
+          "valueBoolean": true
+        },
+        {
+          "url": "collectable",
+          "valueBoolean": true
+        },
+        {
+          "url": "populatable",
+          "valueBoolean": true
+        },
+        {
+          "url": "calculatable",
+          "valueBoolean": true
+        },
+        {
+          "url": "extractable",
+          "valueBoolean": true
+        },
+        {
+          "url": "domainAligned",
+          "valueBoolean": true
+        }
+      ],
+      "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-questionnaire-capabilities"
+    },
+    {
+      "valueExpression": {
+        "name": "rawScore",
+        "language": "text/fhirpath",
+        "expression": "%resource.item.where(linkId.matches('^phq-gad7-q0[1-7]$')).answer.value.ordinal().sum()"
+      },
+      "url": "http://hl7.org/fhir/StructureDefinition/variable"
+    }
+  ],
+  "item": [
+    {
+      "linkId": "GAD-7.Description",
+      "type": "display",
+      "text": "Over the last two weeks, how often have you been bothered by the following problems?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Wie oft fühlten Sie sich im Verlauf der letzten 2 Wochen durch die folgenden Beschwerden beeinträchtigt?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "69725-0",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q01').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q01",
+      "type": "choice",
+      "prefix": "1",
+      "text": "Feeling nervous, anxious, or on edge",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Nervosität, Ängstlichkeit oder Anspannung"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "68509-9",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q02').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q02",
+      "type": "choice",
+      "prefix": "2",
+      "text": "Not being able to stop or control worrying",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Nicht in der Lage sein, Sorgen zu stoppen oder zu kontrollieren"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "69733-4",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q03').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q03",
+      "type": "choice",
+      "prefix": "3",
+      "text": "Worrying too much about different things",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Übermäßige Sorgen bezüglich verschiedener Angelegenheiten"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "69734-2",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q04').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q04",
+      "type": "choice",
+      "prefix": "4",
+      "text": "Trouble relaxing",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Schwierigkeiten, sich zu entspannen"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "69735-9",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q05').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q05",
+      "type": "choice",
+      "prefix": "5",
+      "text": "Being so restless that it is hard to sit still",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Rastlosigkeit, so dass Stillsitzen schwer fällt"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "69689-8",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q06').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q06",
+      "type": "choice",
+      "prefix": "6",
+      "text": "Becoming easily annoyed or irritable",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Schnelle Verärgerung oder Gereiztheit"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "69736-7",
+          "system": "http://loinc.org"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "language": "text/fhirpath",
+            "expression": "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q07').answer.value, {})"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+        }
+      ],
+      "answerOption": [
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6568-5",
+            "display": "Not at all",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Überhaupt nicht"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6569-3",
+            "display": "Several days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An einzelnen Tagen"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6570-1",
+            "display": "More than half the days",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "An mehr als der Hälfte der Tage"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ]
+        },
+        {
+          "valueCoding": {
+            "system": "http://loinc.org",
+            "code": "LA6571-9",
+            "display": "Nearly every day",
+            "_display": {
+              "extension": [
+                {
+                  "extension": [
+                    {
+                      "url": "lang",
+                      "valueCode": "de"
+                    },
+                    {
+                      "url": "content",
+                      "valueString": "Beinahe jeden Tag"
+                    }
+                  ],
+                  "url": "http://hl7.org/fhir/StructureDefinition/translation"
+                }
+              ]
+            }
+          },
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ]
+        }
+      ],
+      "linkId": "phq-gad7-q07",
+      "type": "choice",
+      "prefix": "7",
+      "text": "Feeling afraid, as if something awful might happen",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Gefühl der Angst, so als würde etwas Schlimmes passieren"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "70274-6",
+          "system": "http://loinc.org",
+          "display": "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "name": "Scoreberechnung",
+            "language": "text/fhirpath",
+            "expression": "%rawScore"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+          "valueBoolean": true
+        },
+        {
+          "valueCoding": {
+            "system": "http://unitsofmeasure.org",
+            "code": "{score}"
+          },
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit"
+        },
+        {
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey"
+              }
+            ]
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observation-extract-category"
+        }
+      ],
+      "linkId": "phq-gad7-score-total",
+      "type": "decimal",
+      "prefix": "Auswertung",
+      "readOnly": true,
+      "text": "GAD-7 Total Score",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "GAD-7 Gesamtwert"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    },
+    {
+      "code": [
+        {
+          "code": "77862-1",
+          "system": "http://loinc.org",
+          "display": "PROMIS emotional distress - anxiety - version 1.0 Tscore"
+        }
+      ],
+      "extension": [
+        {
+          "valueExpression": {
+            "name": "promis-anxiety-tscore-mapping",
+            "language": "text/fhirpath",
+            "expression": "iif(%rawScore = 0, 33.8, iif(%rawScore = 1, 40.3, iif(%rawScore = 2, 44.0, iif(%rawScore = 3, 46.8, iif(%rawScore = 4, 49.2, iif(%rawScore = 5, 51.3, iif(%rawScore = 6, 53.2, iif(%rawScore = 7, 54.9, iif(%rawScore = 8, 56.6, iif(%rawScore = 9, 58.1, iif(%rawScore = 10, 59.6, iif(%rawScore = 11, 61.0, iif(%rawScore = 12, 62.3, iif(%rawScore = 13, 63.5, iif(%rawScore = 14, 64.8, iif(%rawScore = 15, 66.0, iif(%rawScore = 16, 67.2, iif(%rawScore = 17, 68.5, iif(%rawScore = 18, 69.8, iif(%rawScore = 19, 71.2, iif(%rawScore = 20, 72.8, 75.7)))))))))))))))))))))"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+          "valueBoolean": true
+        },
+        {
+          "valueCoding": {
+            "system": "http://unitsofmeasure.org",
+            "code": "{score}"
+          },
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit"
+        },
+        {
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey"
+              }
+            ]
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observation-extract-category"
+        }
+      ],
+      "linkId": "phq-gad7-promis-tscore",
+      "type": "decimal",
+      "prefix": "T-Score",
+      "readOnly": true,
+      "text": "PROMIS Anxiety T-Score (derived from GAD-7)",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "PROMIS Angst T-Score (abgeleitet von GAD-7)"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
+    }
+  ],
+  "version": "2026.2.0",
+  "status": "active",
+  "experimental": true,
+  "language": "en"
+}

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-gad-7-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-gad-7-response.json
@@ -1,0 +1,118 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "id": "mii-exa-pro-gad-7-response",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.2.0"
+    ]
+  },
+  "item": [
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6570-1",
+            "system": "http://loinc.org",
+            "display": "More than half the days"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q01"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6571-9",
+            "system": "http://loinc.org",
+            "display": "Nearly every day"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q02"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6570-1",
+            "system": "http://loinc.org",
+            "display": "More than half the days"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q03"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6569-3",
+            "system": "http://loinc.org",
+            "display": "Several days"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q04"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6570-1",
+            "system": "http://loinc.org",
+            "display": "More than half the days"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q05"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6569-3",
+            "system": "http://loinc.org",
+            "display": "Several days"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q06"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "LA6570-1",
+            "system": "http://loinc.org",
+            "display": "More than half the days"
+          }
+        }
+      ],
+      "linkId": "phq-gad7-q07"
+    },
+    {
+      "answer": [
+        {
+          "valueDecimal": 13
+        }
+      ],
+      "linkId": "phq-gad7-score-total"
+    },
+    {
+      "answer": [
+        {
+          "valueDecimal": 63.5
+        }
+      ],
+      "linkId": "phq-gad7-promis-tscore"
+    }
+  ],
+  "status": "completed",
+  "language": "de",
+  "subject": {
+    "reference": "Patient/mii-exa-pro-patient"
+  },
+  "authored": "2024-03-15T10:30:00Z",
+  "questionnaire": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7"
+}

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -1,6 +1,7 @@
 Alias: $mii-cs-pro-eq-5d-value-set =  https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-eq-5d-value-set
 Alias: $mii-qst-pro-euroqol-eq5d5l = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-euroqol-eq5d5l
 Alias: $mii-qst-pro-euroqol-eq5d5l-answer-coding = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-eq5d5l-answer-coding
+Alias: $mii-qst-pro-gad-7 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7
 Alias: $mii-qst-pro-phq-9 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-9
 Alias: $mii-qst-pro-phq-9-sdc-rendering = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-9-sdc-rendering
 Alias: $mii-vs-pro-phq-9-answer-list-ll358-3 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-phq-9-answer-list-ll358-3

--- a/input/fsh/definitions/gad-7/mii-obsdef-pro-score-gad-7.fsh
+++ b/input/fsh/definitions/gad-7/mii-obsdef-pro-score-gad-7.fsh
@@ -1,0 +1,19 @@
+Instance: mii-obsdef-pro-score-gad-7
+InstanceOf: mii-pr-pro-score-blueprint
+Title: "MII ObsDef PRO Score GAD-7"
+Description: "Generalized Anxiety Disorder Scale-7 (GAD-7)"
+Usage: #definition
+* insert ObsDefVersion
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint)
+
+* category.coding = http://terminology.hl7.org/CodeSystem/observation-category#survey
+* code = $LNC#70274-6 "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+* permittedDataType = #Quantity
+* multipleResultsAllowed = false
+* method = $LNC#69737-5 "Generalized anxiety disorder 7 item (GAD-7)"
+* quantitativeDetails.unit = $UCUM#1
+* quantitativeDetails.decimalPrecision = 0
+* qualifiedInterval.category = #absolute
+* qualifiedInterval.range.high.value = 21
+* qualifiedInterval.range.low.value = 0
+* qualifiedInterval.range.extension[ScoreHealthCorrelation].valueCodeableConcept.coding = http://terminology.hl7.org/CodeSystem/measure-improvement-notation#decrease

--- a/input/fsh/definitions/gad-7/mii-qst-pro-gad-7.fsh
+++ b/input/fsh/definitions/gad-7/mii-qst-pro-gad-7.fsh
@@ -1,0 +1,473 @@
+Instance: mii-qst-pro-gad-7
+InstanceOf: mii-pr-pro-questionnaire
+Title: "MII QST PRO GAD-7"
+Description: "Generalized Anxiety Disorder Scale-7 (GAD-7)"
+Usage: #definition
+* insert Version
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire)
+
+* url = $mii-qst-pro-gad-7
+* status = #active
+* experimental = true
+* language = #en
+* code[+] = $LNC#69737-5 "Generalized anxiety disorder 7 item (GAD-7)"
+* code[+] = $mii-cs-pro-questionnaire-catalogue#phq-gad7 "GAD-7 Questionnaire"
+
+* extension[capabilities].extension[displayable].valueBoolean = true
+* extension[capabilities].extension[collectable].valueBoolean = true
+* extension[capabilities].extension[populatable].valueBoolean = true
+* extension[capabilities].extension[calculatable].valueBoolean = true
+* extension[capabilities].extension[extractable].valueBoolean = true
+* extension[capabilities].extension[domainAligned].valueBoolean = true
+
+// Variable for raw score calculation (used by total score and T-score)
+* extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
+* extension[=].valueExpression.name = "rawScore"
+* extension[=].valueExpression.language = #text/fhirpath
+* extension[=].valueExpression.expression = "%resource.item.where(linkId.matches('^phq-gad7-q0[1-7]$')).answer.value.ordinal().sum()"
+
+// ---- Display: Preamble ----
+* item[0].linkId = "GAD-7.Description"
+* item[0].type = #display
+* item[0].text = "Over the last two weeks, how often have you been bothered by the following problems?"
+* item[0].text.extension[0].url = $hl7-translation
+* item[0].text.extension[0].extension[0].url = "lang"
+* item[0].text.extension[0].extension[0].valueCode = #de
+* item[0].text.extension[0].extension[1].url = "content"
+* item[0].text.extension[0].extension[1].valueString = "Wie oft fühlten Sie sich im Verlauf der letzten 2 Wochen durch die folgenden Beschwerden beeinträchtigt?"
+
+// ---- Item 1: Feeling nervous, anxious, or on edge ----
+* item[1].linkId = "phq-gad7-q01"
+* item[1].type = #choice
+* item[1].prefix = "1"
+* item[1].code = $LNC#69725-0
+* item[1].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[1].extension[=].valueExpression.language = #text/fhirpath
+* item[1].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q01').answer.value, {})"
+* item[1].text = "Feeling nervous, anxious, or on edge"
+* item[1].text.extension[0].url = $hl7-translation
+* item[1].text.extension[0].extension[0].url = "lang"
+* item[1].text.extension[0].extension[0].valueCode = #de
+* item[1].text.extension[0].extension[1].url = "content"
+* item[1].text.extension[0].extension[1].valueString = "Nervosität, Ängstlichkeit oder Anspannung"
+* item[1].answerOption[0].valueCoding.system = $LNC
+* item[1].answerOption[0].valueCoding.code = #LA6568-5
+* item[1].answerOption[0].valueCoding.display = "Not at all"
+* item[1].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[1].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[1].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[1].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[1].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[1].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[1].answerOption[0].extension.valueDecimal = 0
+* item[1].answerOption[1].valueCoding.system = $LNC
+* item[1].answerOption[1].valueCoding.code = #LA6569-3
+* item[1].answerOption[1].valueCoding.display = "Several days"
+* item[1].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[1].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[1].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[1].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[1].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[1].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[1].answerOption[1].extension.valueDecimal = 1
+* item[1].answerOption[2].valueCoding.system = $LNC
+* item[1].answerOption[2].valueCoding.code = #LA6570-1
+* item[1].answerOption[2].valueCoding.display = "More than half the days"
+* item[1].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[1].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[1].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[1].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[1].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[1].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[1].answerOption[2].extension.valueDecimal = 2
+* item[1].answerOption[3].valueCoding.system = $LNC
+* item[1].answerOption[3].valueCoding.code = #LA6571-9
+* item[1].answerOption[3].valueCoding.display = "Nearly every day"
+* item[1].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[1].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[1].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[1].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[1].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[1].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[1].answerOption[3].extension.valueDecimal = 3
+
+// ---- Item 2: Not being able to stop or control worrying ----
+* item[2].linkId = "phq-gad7-q02"
+* item[2].type = #choice
+* item[2].prefix = "2"
+* item[2].code = $LNC#68509-9
+* item[2].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[2].extension[=].valueExpression.language = #text/fhirpath
+* item[2].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q02').answer.value, {})"
+* item[2].text = "Not being able to stop or control worrying"
+* item[2].text.extension[0].url = $hl7-translation
+* item[2].text.extension[0].extension[0].url = "lang"
+* item[2].text.extension[0].extension[0].valueCode = #de
+* item[2].text.extension[0].extension[1].url = "content"
+* item[2].text.extension[0].extension[1].valueString = "Nicht in der Lage sein, Sorgen zu stoppen oder zu kontrollieren"
+* item[2].answerOption[0].valueCoding.system = $LNC
+* item[2].answerOption[0].valueCoding.code = #LA6568-5
+* item[2].answerOption[0].valueCoding.display = "Not at all"
+* item[2].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[2].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[2].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[2].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[2].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[2].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[2].answerOption[0].extension.valueDecimal = 0
+* item[2].answerOption[1].valueCoding.system = $LNC
+* item[2].answerOption[1].valueCoding.code = #LA6569-3
+* item[2].answerOption[1].valueCoding.display = "Several days"
+* item[2].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[2].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[2].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[2].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[2].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[2].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[2].answerOption[1].extension.valueDecimal = 1
+* item[2].answerOption[2].valueCoding.system = $LNC
+* item[2].answerOption[2].valueCoding.code = #LA6570-1
+* item[2].answerOption[2].valueCoding.display = "More than half the days"
+* item[2].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[2].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[2].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[2].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[2].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[2].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[2].answerOption[2].extension.valueDecimal = 2
+* item[2].answerOption[3].valueCoding.system = $LNC
+* item[2].answerOption[3].valueCoding.code = #LA6571-9
+* item[2].answerOption[3].valueCoding.display = "Nearly every day"
+* item[2].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[2].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[2].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[2].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[2].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[2].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[2].answerOption[3].extension.valueDecimal = 3
+
+// ---- Item 3: Worrying too much about different things ----
+* item[3].linkId = "phq-gad7-q03"
+* item[3].type = #choice
+* item[3].prefix = "3"
+* item[3].code = $LNC#69733-4
+* item[3].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[3].extension[=].valueExpression.language = #text/fhirpath
+* item[3].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q03').answer.value, {})"
+* item[3].text = "Worrying too much about different things"
+* item[3].text.extension[0].url = $hl7-translation
+* item[3].text.extension[0].extension[0].url = "lang"
+* item[3].text.extension[0].extension[0].valueCode = #de
+* item[3].text.extension[0].extension[1].url = "content"
+* item[3].text.extension[0].extension[1].valueString = "Übermäßige Sorgen bezüglich verschiedener Angelegenheiten"
+* item[3].answerOption[0].valueCoding.system = $LNC
+* item[3].answerOption[0].valueCoding.code = #LA6568-5
+* item[3].answerOption[0].valueCoding.display = "Not at all"
+* item[3].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[3].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[3].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[3].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[3].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[3].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[3].answerOption[0].extension.valueDecimal = 0
+* item[3].answerOption[1].valueCoding.system = $LNC
+* item[3].answerOption[1].valueCoding.code = #LA6569-3
+* item[3].answerOption[1].valueCoding.display = "Several days"
+* item[3].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[3].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[3].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[3].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[3].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[3].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[3].answerOption[1].extension.valueDecimal = 1
+* item[3].answerOption[2].valueCoding.system = $LNC
+* item[3].answerOption[2].valueCoding.code = #LA6570-1
+* item[3].answerOption[2].valueCoding.display = "More than half the days"
+* item[3].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[3].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[3].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[3].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[3].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[3].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[3].answerOption[2].extension.valueDecimal = 2
+* item[3].answerOption[3].valueCoding.system = $LNC
+* item[3].answerOption[3].valueCoding.code = #LA6571-9
+* item[3].answerOption[3].valueCoding.display = "Nearly every day"
+* item[3].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[3].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[3].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[3].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[3].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[3].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[3].answerOption[3].extension.valueDecimal = 3
+
+// ---- Item 4: Trouble relaxing ----
+* item[4].linkId = "phq-gad7-q04"
+* item[4].type = #choice
+* item[4].prefix = "4"
+* item[4].code = $LNC#69734-2
+* item[4].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[4].extension[=].valueExpression.language = #text/fhirpath
+* item[4].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q04').answer.value, {})"
+* item[4].text = "Trouble relaxing"
+* item[4].text.extension[0].url = $hl7-translation
+* item[4].text.extension[0].extension[0].url = "lang"
+* item[4].text.extension[0].extension[0].valueCode = #de
+* item[4].text.extension[0].extension[1].url = "content"
+* item[4].text.extension[0].extension[1].valueString = "Schwierigkeiten, sich zu entspannen"
+* item[4].answerOption[0].valueCoding.system = $LNC
+* item[4].answerOption[0].valueCoding.code = #LA6568-5
+* item[4].answerOption[0].valueCoding.display = "Not at all"
+* item[4].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[4].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[4].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[4].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[4].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[4].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[4].answerOption[0].extension.valueDecimal = 0
+* item[4].answerOption[1].valueCoding.system = $LNC
+* item[4].answerOption[1].valueCoding.code = #LA6569-3
+* item[4].answerOption[1].valueCoding.display = "Several days"
+* item[4].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[4].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[4].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[4].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[4].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[4].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[4].answerOption[1].extension.valueDecimal = 1
+* item[4].answerOption[2].valueCoding.system = $LNC
+* item[4].answerOption[2].valueCoding.code = #LA6570-1
+* item[4].answerOption[2].valueCoding.display = "More than half the days"
+* item[4].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[4].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[4].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[4].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[4].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[4].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[4].answerOption[2].extension.valueDecimal = 2
+* item[4].answerOption[3].valueCoding.system = $LNC
+* item[4].answerOption[3].valueCoding.code = #LA6571-9
+* item[4].answerOption[3].valueCoding.display = "Nearly every day"
+* item[4].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[4].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[4].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[4].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[4].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[4].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[4].answerOption[3].extension.valueDecimal = 3
+
+// ---- Item 5: Being so restless that it is hard to sit still ----
+* item[5].linkId = "phq-gad7-q05"
+* item[5].type = #choice
+* item[5].prefix = "5"
+* item[5].code = $LNC#69735-9
+* item[5].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[5].extension[=].valueExpression.language = #text/fhirpath
+* item[5].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q05').answer.value, {})"
+* item[5].text = "Being so restless that it is hard to sit still"
+* item[5].text.extension[0].url = $hl7-translation
+* item[5].text.extension[0].extension[0].url = "lang"
+* item[5].text.extension[0].extension[0].valueCode = #de
+* item[5].text.extension[0].extension[1].url = "content"
+* item[5].text.extension[0].extension[1].valueString = "Rastlosigkeit, so dass Stillsitzen schwer fällt"
+* item[5].answerOption[0].valueCoding.system = $LNC
+* item[5].answerOption[0].valueCoding.code = #LA6568-5
+* item[5].answerOption[0].valueCoding.display = "Not at all"
+* item[5].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[5].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[5].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[5].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[5].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[5].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[5].answerOption[0].extension.valueDecimal = 0
+* item[5].answerOption[1].valueCoding.system = $LNC
+* item[5].answerOption[1].valueCoding.code = #LA6569-3
+* item[5].answerOption[1].valueCoding.display = "Several days"
+* item[5].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[5].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[5].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[5].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[5].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[5].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[5].answerOption[1].extension.valueDecimal = 1
+* item[5].answerOption[2].valueCoding.system = $LNC
+* item[5].answerOption[2].valueCoding.code = #LA6570-1
+* item[5].answerOption[2].valueCoding.display = "More than half the days"
+* item[5].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[5].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[5].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[5].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[5].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[5].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[5].answerOption[2].extension.valueDecimal = 2
+* item[5].answerOption[3].valueCoding.system = $LNC
+* item[5].answerOption[3].valueCoding.code = #LA6571-9
+* item[5].answerOption[3].valueCoding.display = "Nearly every day"
+* item[5].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[5].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[5].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[5].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[5].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[5].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[5].answerOption[3].extension.valueDecimal = 3
+
+// ---- Item 6: Becoming easily annoyed or irritable ----
+* item[6].linkId = "phq-gad7-q06"
+* item[6].type = #choice
+* item[6].prefix = "6"
+* item[6].code = $LNC#69689-8
+* item[6].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[6].extension[=].valueExpression.language = #text/fhirpath
+* item[6].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q06').answer.value, {})"
+* item[6].text = "Becoming easily annoyed or irritable"
+* item[6].text.extension[0].url = $hl7-translation
+* item[6].text.extension[0].extension[0].url = "lang"
+* item[6].text.extension[0].extension[0].valueCode = #de
+* item[6].text.extension[0].extension[1].url = "content"
+* item[6].text.extension[0].extension[1].valueString = "Schnelle Verärgerung oder Gereiztheit"
+* item[6].answerOption[0].valueCoding.system = $LNC
+* item[6].answerOption[0].valueCoding.code = #LA6568-5
+* item[6].answerOption[0].valueCoding.display = "Not at all"
+* item[6].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[6].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[6].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[6].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[6].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[6].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[6].answerOption[0].extension.valueDecimal = 0
+* item[6].answerOption[1].valueCoding.system = $LNC
+* item[6].answerOption[1].valueCoding.code = #LA6569-3
+* item[6].answerOption[1].valueCoding.display = "Several days"
+* item[6].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[6].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[6].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[6].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[6].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[6].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[6].answerOption[1].extension.valueDecimal = 1
+* item[6].answerOption[2].valueCoding.system = $LNC
+* item[6].answerOption[2].valueCoding.code = #LA6570-1
+* item[6].answerOption[2].valueCoding.display = "More than half the days"
+* item[6].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[6].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[6].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[6].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[6].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[6].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[6].answerOption[2].extension.valueDecimal = 2
+* item[6].answerOption[3].valueCoding.system = $LNC
+* item[6].answerOption[3].valueCoding.code = #LA6571-9
+* item[6].answerOption[3].valueCoding.display = "Nearly every day"
+* item[6].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[6].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[6].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[6].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[6].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[6].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[6].answerOption[3].extension.valueDecimal = 3
+
+// ---- Item 7: Feeling afraid, as if something awful might happen ----
+* item[7].linkId = "phq-gad7-q07"
+* item[7].type = #choice
+* item[7].prefix = "7"
+* item[7].code = $LNC#69736-7
+* item[7].extension[+].url = "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-initialExpression"
+* item[7].extension[=].valueExpression.language = #text/fhirpath
+* item[7].extension[=].valueExpression.expression = "iif(%sourceResponse.exists(), %sourceResponse.item.where(linkId='phq-gad7-q07').answer.value, {})"
+* item[7].text = "Feeling afraid, as if something awful might happen"
+* item[7].text.extension[0].url = $hl7-translation
+* item[7].text.extension[0].extension[0].url = "lang"
+* item[7].text.extension[0].extension[0].valueCode = #de
+* item[7].text.extension[0].extension[1].url = "content"
+* item[7].text.extension[0].extension[1].valueString = "Gefühl der Angst, so als würde etwas Schlimmes passieren"
+* item[7].answerOption[0].valueCoding.system = $LNC
+* item[7].answerOption[0].valueCoding.code = #LA6568-5
+* item[7].answerOption[0].valueCoding.display = "Not at all"
+* item[7].answerOption[0].valueCoding.display.extension[0].url = $hl7-translation
+* item[7].answerOption[0].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[7].answerOption[0].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[7].answerOption[0].valueCoding.display.extension[0].extension[1].url = "content"
+* item[7].answerOption[0].valueCoding.display.extension[0].extension[1].valueString = "Überhaupt nicht"
+* item[7].answerOption[0].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[7].answerOption[0].extension.valueDecimal = 0
+* item[7].answerOption[1].valueCoding.system = $LNC
+* item[7].answerOption[1].valueCoding.code = #LA6569-3
+* item[7].answerOption[1].valueCoding.display = "Several days"
+* item[7].answerOption[1].valueCoding.display.extension[0].url = $hl7-translation
+* item[7].answerOption[1].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[7].answerOption[1].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[7].answerOption[1].valueCoding.display.extension[0].extension[1].url = "content"
+* item[7].answerOption[1].valueCoding.display.extension[0].extension[1].valueString = "An einzelnen Tagen"
+* item[7].answerOption[1].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[7].answerOption[1].extension.valueDecimal = 1
+* item[7].answerOption[2].valueCoding.system = $LNC
+* item[7].answerOption[2].valueCoding.code = #LA6570-1
+* item[7].answerOption[2].valueCoding.display = "More than half the days"
+* item[7].answerOption[2].valueCoding.display.extension[0].url = $hl7-translation
+* item[7].answerOption[2].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[7].answerOption[2].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[7].answerOption[2].valueCoding.display.extension[0].extension[1].url = "content"
+* item[7].answerOption[2].valueCoding.display.extension[0].extension[1].valueString = "An mehr als der Hälfte der Tage"
+* item[7].answerOption[2].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[7].answerOption[2].extension.valueDecimal = 2
+* item[7].answerOption[3].valueCoding.system = $LNC
+* item[7].answerOption[3].valueCoding.code = #LA6571-9
+* item[7].answerOption[3].valueCoding.display = "Nearly every day"
+* item[7].answerOption[3].valueCoding.display.extension[0].url = $hl7-translation
+* item[7].answerOption[3].valueCoding.display.extension[0].extension[0].url = "lang"
+* item[7].answerOption[3].valueCoding.display.extension[0].extension[0].valueCode = #de
+* item[7].answerOption[3].valueCoding.display.extension[0].extension[1].url = "content"
+* item[7].answerOption[3].valueCoding.display.extension[0].extension[1].valueString = "Beinahe jeden Tag"
+* item[7].answerOption[3].extension.url = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* item[7].answerOption[3].extension.valueDecimal = 3
+
+// ---- GAD-7 Total Score (calculated, extractable) ----
+* item[8].linkId = "phq-gad7-score-total"
+* item[8].type = #decimal
+* item[8].prefix = "Auswertung"
+* item[8].code = $LNC#70274-6 "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+* item[8].readOnly = true
+* item[8].extension[0].url = $sdc-questionnaire-calculated-expression
+* item[8].extension[0].valueExpression.name = "Scoreberechnung"
+* item[8].extension[0].valueExpression.language = #text/fhirpath
+* item[8].extension[0].valueExpression.expression = "%rawScore"
+* item[8].text = "GAD-7 Total Score"
+* item[8].text.extension[0].url = $hl7-translation
+* item[8].text.extension[0].extension[0].url = "lang"
+* item[8].text.extension[0].extension[0].valueCode = #de
+* item[8].text.extension[0].extension[1].url = "content"
+* item[8].text.extension[0].extension[1].valueString = "GAD-7 Gesamtwert"
+* item[8].extension[1].url = $sdc-questionnaire-observation-extract
+* item[8].extension[1].valueBoolean = true
+* item[8].extension[2].url = $hl7-questionnaire-unit
+* item[8].extension[2].valueCoding.system = $UCUM
+* item[8].extension[2].valueCoding.code = #{score}
+* item[8].extension[3].url = $sdc-questionnaire-observation-extract-category
+* item[8].extension[3].valueCodeableConcept.coding.system = $hl7-observation-category
+* item[8].extension[3].valueCodeableConcept.coding.code = #survey
+
+// ---- PROMIS Anxiety T-Score (derived from GAD-7 via PROsetta Stone crosswalk) ----
+* item[9].linkId = "phq-gad7-promis-tscore"
+* item[9].type = #decimal
+* item[9].prefix = "T-Score"
+* item[9].code = $LNC#77862-1 "PROMIS emotional distress - anxiety - version 1.0 Tscore"
+* item[9].readOnly = true
+* item[9].extension[0].url = $sdc-questionnaire-calculated-expression
+* item[9].extension[0].valueExpression.name = "promis-anxiety-tscore-mapping"
+* item[9].extension[0].valueExpression.language = #text/fhirpath
+* item[9].extension[0].valueExpression.expression = "iif(%rawScore = 0, 33.8, iif(%rawScore = 1, 40.3, iif(%rawScore = 2, 44.0, iif(%rawScore = 3, 46.8, iif(%rawScore = 4, 49.2, iif(%rawScore = 5, 51.3, iif(%rawScore = 6, 53.2, iif(%rawScore = 7, 54.9, iif(%rawScore = 8, 56.6, iif(%rawScore = 9, 58.1, iif(%rawScore = 10, 59.6, iif(%rawScore = 11, 61.0, iif(%rawScore = 12, 62.3, iif(%rawScore = 13, 63.5, iif(%rawScore = 14, 64.8, iif(%rawScore = 15, 66.0, iif(%rawScore = 16, 67.2, iif(%rawScore = 17, 68.5, iif(%rawScore = 18, 69.8, iif(%rawScore = 19, 71.2, iif(%rawScore = 20, 72.8, 75.7)))))))))))))))))))))"
+* item[9].text = "PROMIS Anxiety T-Score (derived from GAD-7)"
+* item[9].text.extension[0].url = $hl7-translation
+* item[9].text.extension[0].extension[0].url = "lang"
+* item[9].text.extension[0].extension[0].valueCode = #de
+* item[9].text.extension[0].extension[1].url = "content"
+* item[9].text.extension[0].extension[1].valueString = "PROMIS Angst T-Score (abgeleitet von GAD-7)"
+* item[9].extension[1].url = $sdc-questionnaire-observation-extract
+* item[9].extension[1].valueBoolean = true
+* item[9].extension[2].url = $hl7-questionnaire-unit
+* item[9].extension[2].valueCoding.system = $UCUM
+* item[9].extension[2].valueCoding.code = #{score}
+* item[9].extension[3].url = $sdc-questionnaire-observation-extract-category
+* item[9].extension[3].valueCodeableConcept.coding.system = $hl7-observation-category
+* item[9].extension[3].valueCodeableConcept.coding.code = #survey
+// Reference: PROsetta Stone® GAD-7 to PROMIS Anxiety Crosswalk Table. Available at: https://www.prosettastone.org

--- a/input/fsh/examples/mii-exa-pro-gad-7-bundle.fsh
+++ b/input/fsh/examples/mii-exa-pro-gad-7-bundle.fsh
@@ -1,0 +1,35 @@
+Instance: mii-exa-pro-gad-7-bundle
+InstanceOf: Bundle
+Title: "GAD-7 Transaction Bundle Example"
+Description: "Transaction bundle containing GAD-7 questionnaire, response, and derived observation"
+Usage: #example
+* type = #transaction
+
+// Questionnaire
+* entry[+].fullUrl = "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7"
+* entry[=].resource = mii-qst-pro-gad-7
+* entry[=].request.method = #PUT
+* entry[=].request.url = "Questionnaire/mii-qst-pro-gad-7"
+
+// QuestionnaireResponse (moderate anxiety example)
+* entry[+].fullUrl = "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/QuestionnaireResponse/mii-exa-pro-gad-7-response"
+* entry[=].resource = mii-exa-pro-gad-7-response
+* entry[=].request.method = #PUT
+* entry[=].request.url = "QuestionnaireResponse/mii-exa-pro-gad-7-response"
+
+// Derived Observation (score 13)
+* entry[+].fullUrl = "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Observation/mii-exa-pro-gad-7-observation"
+* entry[=].resource = mii-exa-pro-gad-7-observation
+* entry[=].request.method = #PUT
+* entry[=].request.url = "Observation/mii-exa-pro-gad-7-observation"
+
+// Patient (reuse existing example patient)
+* entry[+].fullUrl = "http://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Patient/mii-exa-pro-patient"
+* entry[=].resource.resourceType = "Patient"
+* entry[=].resource.id = "mii-exa-pro-patient"
+* entry[=].resource.active = true
+* entry[=].resource.name.family = "Example"
+* entry[=].resource.name.given = "Patient"
+* entry[=].resource.gender = #other
+* entry[=].request.method = #PUT
+* entry[=].request.url = "Patient/mii-exa-pro-patient"

--- a/input/fsh/examples/mii-exa-pro-gad-7-observation.fsh
+++ b/input/fsh/examples/mii-exa-pro-gad-7-observation.fsh
@@ -1,0 +1,14 @@
+// Example Observation-based Extraction, see https://build.fhir.org/ig/HL7/sdc/extraction.html#obs-extract
+Instance: mii-exa-pro-gad-7-observation
+InstanceOf: MII_PR_PRO_Score_Instance
+Usage: #example
+Title: "GAD-7 Observation Example"
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance)
+* status = #final
+* subject = Reference(Patient/mii-exa-pro-patient)
+* effectiveDateTime = "2024-03-15T10:30:00Z"
+* code = $LNC#70274-6 "Generalized anxiety disorder 7 item (GAD-7) total score [Reported.PHQ]"
+* valueQuantity.value = 13
+* valueQuantity.code = #{score}
+* valueQuantity.unit = "{score}"
+* valueQuantity.system = $UCUM

--- a/input/fsh/examples/mii-exa-pro-gad-7-response.fsh
+++ b/input/fsh/examples/mii-exa-pro-gad-7-response.fsh
@@ -1,0 +1,40 @@
+Instance: mii-exa-pro-gad-7-response
+InstanceOf: MII_PR_PRO_QuestionnaireResponse
+Usage: #example
+Title: "GAD-7 Questionnaire Response Example"
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response)
+* status = #completed
+* language = #de
+* subject = Reference(Patient/mii-exa-pro-patient)
+* authored = "2024-03-15T10:30:00Z"
+* questionnaire = $mii-qst-pro-gad-7
+
+// Moderate anxiety responses (score = 13)
+* item[+].linkId = "phq-gad7-q01" // Feeling nervous, anxious, or on edge
+* item[=].answer[0].valueCoding = $LNC#LA6570-1 "More than half the days"
+
+* item[+].linkId = "phq-gad7-q02" // Not being able to stop or control worrying
+* item[=].answer[0].valueCoding = $LNC#LA6571-9 "Nearly every day"
+
+* item[+].linkId = "phq-gad7-q03" // Worrying too much about different things
+* item[=].answer[0].valueCoding = $LNC#LA6570-1 "More than half the days"
+
+* item[+].linkId = "phq-gad7-q04" // Trouble relaxing
+* item[=].answer[0].valueCoding = $LNC#LA6569-3 "Several days"
+
+* item[+].linkId = "phq-gad7-q05" // Being so restless that it is hard to sit still
+* item[=].answer[0].valueCoding = $LNC#LA6570-1 "More than half the days"
+
+* item[+].linkId = "phq-gad7-q06" // Becoming easily annoyed or irritable
+* item[=].answer[0].valueCoding = $LNC#LA6569-3 "Several days"
+
+* item[+].linkId = "phq-gad7-q07" // Feeling afraid, as if something awful might happen
+* item[=].answer[0].valueCoding = $LNC#LA6570-1 "More than half the days"
+
+// Total score: 2+3+2+1+2+1+2 = 13 (moderate anxiety)
+* item[+].linkId = "phq-gad7-score-total"
+* item[=].answer[0].valueDecimal = 13
+
+// PROMIS Anxiety T-Score (from PROsetta Stone crosswalk: score 13 → 63.5)
+* item[+].linkId = "phq-gad7-promis-tscore"
+* item[=].answer[0].valueDecimal = 63.5

--- a/input/fsh/profiles/mii-cs-pro-questionnaire-catalogue.fsh
+++ b/input/fsh/profiles/mii-cs-pro-questionnaire-catalogue.fsh
@@ -9,6 +9,7 @@ Description: "MII CS PRO Questionnaire Catalogue for PRO Questionnaires used in 
 * ^status = #active
 
 * #euroqol-eq5d5l "EuroQol EQ-5D-5L Questionnaire"
+* #phq-gad7 "GAD-7 Questionnaire"
 * #phq-phq9 "PHQ-9 Questionnaire"
 * #bdi-bdi2 "Beck Depression Inventory II (BDI-II)"
 * #promis-promis29 "PROMIS-29 Questionnaire"

--- a/input/fsh/profiles/mii-cs-pro-score-catalogue.fsh
+++ b/input/fsh/profiles/mii-cs-pro-score-catalogue.fsh
@@ -13,6 +13,10 @@ Description: "MII CS PRO Score Catalogue for PRO Scores used in the MII PROMs Mo
 * #euroqol-eq5d5l-vas "EuroQol EQ-5D-5L Visual Analog Scale (VAS) Score"
 * #euroqol-eq5d5l-profile "EuroQol EQ-5D-5L Profile"
 
+// GAD-7 Scores
+* #phq-gad7-total "GAD-7 Total Score"
+* #phq-gad7-promis-anxiety-tscore "GAD-7 derived PROMIS Anxiety T-Score"
+
 // PHQ-9 Scores
 * #phq-phq9-total "PHQ-9 Total Score"
 

--- a/input/pagecontent/gad-7.md
+++ b/input/pagecontent/gad-7.md
@@ -1,0 +1,67 @@
+### Klinischer Kontext
+
+Der GAD-7 (Generalized Anxiety Disorder Scale-7) ist ein validiertes Screening-Instrument für generalisierte Angststörungen mit sieben Items. Das Instrument erfasst die Häufigkeit von Angstsymptomen über einen Zeitraum von zwei Wochen auf einer vierstufigen Skala (0-3).
+
+**Scoring und Interpretation:**
+- 0-4: Minimale Angst
+- 5-9: Milde Angst
+- 10-14: Moderate Angst
+- 15-21: Schwere Angst
+
+**Onkologie-spezifische Cut-offs:** Neuere Evidenz empfiehlt Cut-off ≥7 oder ≥8 für Krebspatienten (Sensitivität/Spezifität optimiert für onkologische Populationen).
+
+**Kurzform GAD-2:** Die ersten zwei Items (nervös/ängstlich + Sorgen nicht kontrollieren können) bilden den GAD-2 mit Cut-off ≥3.
+
+### FHIR-Implementierung
+
+> **Sprachstrategie:** Der GAD-7 wird mit Englisch als Primärsprache implementiert, da die Originalversion des Instruments in Englisch verfasst ist. Deutsche Übersetzungen sind als Translations hinterlegt. Dies gewährleistet die korrekte Validierung gegen LOINC-Terminologien.
+
+#### Questionnaire
+
+**Canonical URL:** `https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7`
+
+**Implementierte Capabilities:**
+- Displayable, Collectable, Populatable, Calculatable, Extractable, Domain-aligned
+
+**Besonderheiten:**
+- Automatische Score-Berechnung via FHIRPath: `%resource.item.where(linkId.matches('^phq-gad7-q0[1-7]$')).answer.value.ordinal().sum()`
+- Populatable für server-seitige Berechnungen implementiert
+- LOINC-kodierte Antwortoptionen mit ordinalValue-Extension
+- PROMIS Anxiety T-Score Crosswalk integriert (PROsetta Stone)
+
+Die vollständige Ressource finden Sie in der [Questionnaire-Definition](Questionnaire-mii-qst-pro-gad-7.html).
+
+#### Score-Repräsentation
+
+Der GAD-7 Score wird auf mehreren Ebenen repräsentiert:
+
+1. **Als berechnetes Item** in der QuestionnaireResponse (linkId: `phq-gad7-score-total`)
+2. **Als Observation** mit LOINC-Code 70274-6 "GAD-7 total score"
+3. **Als Domain-Score** gemappt auf PROMIS Anxiety T-Score
+
+**ObservationDefinition:** `mii-obsdef-pro-score-gad-7`
+- Definiert Wertebereich: 0-21 {score}
+- Spezifiziert Interpretationsrichtlinien
+- Score-Richtung: decrease (niedrigerer Wert = bessere Gesundheit)
+
+### Domain-Mapping
+
+Der GAD-7 kann auf PROMIS Anxiety T-Scores gemappt werden (PROsetta Stone Crosswalk):
+
+| GAD-7 Score | PROMIS T-Score | Interpretation |
+|-------------|----------------|----------------|
+| 0-4         | ~33.8–49.2     | Minimal        |
+| 5-9         | ~51.3–58.1     | Mild           |
+| 10-14       | ~59.6–64.8     | Moderat        |
+| 15-21       | ~66.0–75.7     | Schwer         |
+
+### Validierung
+
+**Technisch:** Score-Bereich 0-21, alle 7 Items für validen Score erforderlich, Ordinal-Werte: 0, 1, 2, 3
+
+**Klinisch:** Sensitivität 89%, Spezifität 82% für generalisierte Angststörung (Cut-off ≥10), Cronbach's Alpha: 0.92, Test-Retest-Reliabilität: ICC 0.83
+
+### Referenzen
+
+- Spitzer RL, Kroenke K, Williams JBW, Löwe B. A Brief Measure for Assessing Generalized Anxiety Disorder: The GAD-7. Arch Intern Med. 2006;166(10):1092–1097. [DOI: 10.1001/archinte.166.10.1092](https://doi.org/10.1001/archinte.166.10.1092)
+- Löwe B, et al. Validation and Standardization of the Generalized Anxiety Disorder Screener (GAD-7) in the General Population. Med Care. 2008;46(3):266–274. [DOI: 10.1097/MLR.0b013e318160d093](https://doi.org/10.1097/MLR.0b013e318160d093)

--- a/input/translations/en/pagecontent/gad-7.md
+++ b/input/translations/en/pagecontent/gad-7.md
@@ -1,0 +1,67 @@
+### Clinical Context
+
+The GAD-7 (Generalized Anxiety Disorder Scale-7) is a validated screening instrument for generalized anxiety disorder with seven items. The instrument assesses the frequency of anxiety symptoms over a two-week period on a four-point scale (0-3).
+
+**Scoring and Interpretation:**
+- 0-4: Minimal anxiety
+- 5-9: Mild anxiety
+- 10-14: Moderate anxiety
+- 15-21: Severe anxiety
+
+**Oncology-specific cut-offs:** Recent evidence recommends cut-off ≥7 or ≥8 for cancer patients (sensitivity/specificity optimized for oncological populations).
+
+**Short form GAD-2:** The first two items (feeling nervous/anxious + not able to stop worrying) form the GAD-2 with cut-off ≥3.
+
+### FHIR Implementation
+
+> **Language Strategy:** The GAD-7 is implemented with English as the primary language, as the original version of the instrument was written in English. German translations are provided as Translation extensions. This ensures correct validation against LOINC terminologies.
+
+#### Questionnaire
+
+**Canonical URL:** `https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-gad-7`
+
+**Implemented Capabilities:**
+- Displayable, Collectable, Populatable, Calculatable, Extractable, Domain-aligned
+
+**Key Features:**
+- Automatic score calculation via FHIRPath: `%resource.item.where(linkId.matches('^phq-gad7-q0[1-7]$')).answer.value.ordinal().sum()`
+- Populatable capability for server-side calculations implemented
+- LOINC-coded answer options with ordinalValue extension
+- PROMIS Anxiety T-Score crosswalk integrated (PROsetta Stone)
+
+See the [Questionnaire definition](Questionnaire-mii-qst-pro-gad-7.html) for the full resource.
+
+#### Score Representation
+
+The GAD-7 score is represented at multiple levels:
+
+1. **As a calculated item** in the QuestionnaireResponse (linkId: `phq-gad7-score-total`)
+2. **As an Observation** with LOINC code 70274-6 "GAD-7 total score"
+3. **As a domain score** mapped to PROMIS Anxiety T-Score
+
+**ObservationDefinition:** `mii-obsdef-pro-score-gad-7`
+- Defines value range: 0-21 {score}
+- Specifies interpretation guidelines
+- Score direction: decrease (lower value = better health)
+
+### Domain Mapping
+
+The GAD-7 can be mapped to PROMIS Anxiety T-Scores (PROsetta Stone Crosswalk):
+
+| GAD-7 Score | PROMIS T-Score | Interpretation |
+|-------------|----------------|----------------|
+| 0-4         | ~33.8–49.2     | Minimal        |
+| 5-9         | ~51.3–58.1     | Mild           |
+| 10-14       | ~59.6–64.8     | Moderate       |
+| 15-21       | ~66.0–75.7     | Severe         |
+
+### Validation
+
+**Technical:** Score range 0-21, all 7 items required for a valid score, ordinal values: 0, 1, 2, 3
+
+**Clinical:** Sensitivity 89%, specificity 82% for generalized anxiety disorder (cut-off ≥10), Cronbach's alpha: 0.92, test-retest reliability: ICC 0.83
+
+### References
+
+- Spitzer RL, Kroenke K, Williams JBW, Löwe B. A Brief Measure for Assessing Generalized Anxiety Disorder: The GAD-7. Arch Intern Med. 2006;166(10):1092–1097. [DOI: 10.1001/archinte.166.10.1092](https://doi.org/10.1001/archinte.166.10.1092)
+- Löwe B, et al. Validation and Standardization of the Generalized Anxiety Disorder Screener (GAD-7) in the General Population. Med Care. 2008;46(3):266–274. [DOI: 10.1097/MLR.0b013e318160d093](https://doi.org/10.1097/MLR.0b013e318160d093)

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -120,6 +120,8 @@ pages:
     title: PRO Library
     phq-9.md:
       title: PHQ-9
+    gad-7.md:
+      title: GAD-7
     eq-5d-5l.md:
       title: EQ-5D-5L
       eq-5d-5l-scores.md:
@@ -174,6 +176,7 @@ menu:
   PRO Library:
     PRO Library: pro-library.html
     PHQ-9: phq-9.html
+    GAD-7: gad-7.html
     EQ-5D-5L: eq-5d-5l.html
     EORTC QLQ-C30: eortc-qlq-c30.html
     PROMIS: promis.html


### PR DESCRIPTION
## Summary

- GAD-7 (Generalized Anxiety Disorder Scale-7) FHIR Questionnaire implementation following PHQ-9 pattern
- 7 LOINC-coded items with EN primary language + DE translations, ordinalValue extensions (0-3)
- Automatic score calculation via FHIRPath `.ordinal().sum()` + PROMIS Anxiety T-Score crosswalk (PROsetta Stone)
- ObservationDefinition, example QuestionnaireResponse/Observation/Bundle, IG pages (DE+EN)

Closes #80

## Test plan

- [ ] SUSHI compiles without errors (`npx sushi .`)
- [ ] IG Publisher builds successfully
- [ ] Questionnaire renders correctly with score calculation
- [ ] Example QuestionnaireResponse validates against profile
- [ ] PROMIS Anxiety T-Score crosswalk values verified against PROsetta Stone tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)