### PR TITLE
ci(ig-publisher): ValueSets nach SUSHI expandieren (behebt answerValueSet-QA-Findings)

### DIFF
--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -74,6 +74,14 @@ jobs:
       - name: Run SUSHI
         run: docker run --rm --network host -v $PWD:/workspace -v /usr/bin/dot:/usr/local/bin/dot:ro -v /usr/lib/x86_64-linux-gnu:/usr/host/lib:ro -e LD_LIBRARY_PATH="/usr/host/lib:$LD_LIBRARY_PATH" -w /workspace ghcr.io/gefyra/ig-publisher-with-snapshot-support:latest sushi .
 
+      # Expand ValueSets against local CodeSystems (adds vs.expansion) so the IG
+      # Publisher / validator can confirm answerValueSet answer membership for
+      # MII-controlled answer scales (fixes 'not in options' on example
+      # QuestionnaireResponses). Dependency-free node script; mirrors the local
+      # pre-commit hook, which CI otherwise skips.
+      - name: Expand ValueSets (post-SUSHI)
+        run: node expand-valuesets.js
+
       # Run the HL7 FHIR IG Publisher
       - name: Build IG
         run: |


### PR DESCRIPTION
## Problem
Das lokale `expand-valuesets.js` (im pre-commit-Hook) schreibt `vs.expansion` aus lokalen CodeSystems. Das **CI** führte es aber nicht aus: der IG-Build regeneriert per SUSHI ohne Expansion, sodass der Validator die MII-CS-basierten `answerValueSet`-Bindungen nicht auflösen kann → der QA-Report meldet für Beispiel-`QuestionnaireResponse`s „Der angegebene Wert ist nicht in den im Fragebogen angegebenen Optionen" (PHQ-15, WHODAS, …).

## Fix
Ein Schritt **nach „Run SUSHI", vor „Build IG"** in `ig-publisher.yml`:
```yaml
- name: Expand ValueSets (post-SUSHI)
  run: node expand-valuesets.js
```
Dependency-freies Node-Skript (nur `fs`/`path`), läuft auf dem Runner gegen das von SUSHI erzeugte `fsh-generated/`. Erhält Designations + ordinalValue.

## Wirkung
- QA-Report wird sauber für alle answerValueSet-Instrumente (auch retroaktiv PHQ-15 beim nächsten dev-Build).
- Kein inline `answerOption` nötig; die strategische answerValueSet-Linie bleibt.

## Hinweis / offen
Der DOTNET-Validierungsjob nutzt einen reusable Workflow aus `kerndatensatz-meta` (nicht hier editierbar) — falls dieser SUSHI ohne Expansion regeneriert/committet, wäre dort perspektivisch derselbe Schritt sinnvoll.

🤖 Generated with [Claude Code](https://claude.com/claude-code)