### PR TITLE
feat(whodas): WHODAS 2.0 12-Item integrieren mit korrekten WHO-Lizenzbedingungen

### DIFF
--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-questionnaire-catalogue.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-questionnaire-catalogue.json
@@ -79,6 +79,10 @@
     {
       "code": "midos-midos2",
       "display": "MIDOS2 (Minimales Dokumentationssystem für Palliativpatienten, DGP)"
+    },
+    {
+      "code": "whodas-whodas12",
+      "display": "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
     }
   ],
   "version": "2026.4.1",

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-score-catalogue.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-score-catalogue.json
@@ -161,6 +161,10 @@
       "display": "DASS-21 Stress DASS-42 Equivalent Score"
     },
     {
+      "code": "whodas12-simple-sum",
+      "display": "WHODAS 2.0 12-Item Simple Sum Score (0-48)"
+    },
+    {
       "code": "proctcae-composite-grade",
       "display": "PRO-CTCAE Composite Grade (per Adverse Event)"
     },

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
@@ -5,7 +5,7 @@
   "name": "MII_CS_PRO_WHODAS_12",
   "id": "mii-cs-pro-whodas-12",
   "title": "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes",
-  "description": "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed.",
+  "description": "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. WHODAS 2.0 © WHO 2010; electronic use requires a WHO licence (see copyright).",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
   "concept": [
     {
@@ -213,6 +213,7 @@
   "experimental": true,
   "caseSensitive": true,
   "language": "en",
+  "copyright": "WHODAS 2.0 © World Health Organization 2010. Scale/item text used under WHO terms; electronic or data-capture use requires a WHO licence agreement (free of charge for non-commercial use) via the WHO Classifications licensing process. MII-authored FHIR content is licensed CC0.",
   "property": [
     {
       "code": "ordinalValue",

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
@@ -1,0 +1,84 @@
+{
+  "resourceType": "CodeSystem",
+  "status": "active",
+  "content": "complete",
+  "name": "MII_CS_PRO_WHODAS_12",
+  "id": "mii-cs-pro-whodas-12",
+  "title": "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes",
+  "description": "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with answer codes and item codes. German (de-DE) primary text from the validated PCOR-MII Item Level Dictionary (MASTER_3EntitiesOverview.xlsx). Ordinal scoring weights are applied at the Questionnaire level via ordinalValue extensions. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed.",
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+  "concept": [
+    {
+      "code": "whodas12-answer-0",
+      "display": "keine"
+    },
+    {
+      "code": "whodas12-answer-1",
+      "display": "geringe"
+    },
+    {
+      "code": "whodas12-answer-2",
+      "display": "mäßige"
+    },
+    {
+      "code": "whodas12-answer-3",
+      "display": "starke"
+    },
+    {
+      "code": "whodas12-answer-4",
+      "display": "sehr starke/nicht möglich"
+    },
+    {
+      "code": "whodas12-q01",
+      "display": "längere Zeit (ca. 30 min) zu stehen?"
+    },
+    {
+      "code": "whodas12-q02",
+      "display": "Ihren Haushaltspflichten nachzukommen?"
+    },
+    {
+      "code": "whodas12-q03",
+      "display": "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+    },
+    {
+      "code": "whodas12-q04",
+      "display": "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+    },
+    {
+      "code": "whodas12-q05",
+      "display": "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+    },
+    {
+      "code": "whodas12-q06",
+      "display": "Sich auf etwas für 10 Minuten zu konzentrieren?"
+    },
+    {
+      "code": "whodas12-q07",
+      "display": "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+    },
+    {
+      "code": "whodas12-q08",
+      "display": "Ihren gesamten Körper zu waschen?"
+    },
+    {
+      "code": "whodas12-q09",
+      "display": "sich anzuziehen?"
+    },
+    {
+      "code": "whodas12-q10",
+      "display": "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+    },
+    {
+      "code": "whodas12-q11",
+      "display": "Eine Freundschaft aufrechtzuerhalten?"
+    },
+    {
+      "code": "whodas12-q12",
+      "display": "Bei der Bewältigung des Arbeits-/Schulalltags?"
+    }
+  ],
+  "version": "2026.4.1",
+  "experimental": true,
+  "caseSensitive": true,
+  "count": 17
+}

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
@@ -5,80 +5,221 @@
   "name": "MII_CS_PRO_WHODAS_12",
   "id": "mii-cs-pro-whodas-12",
   "title": "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes",
-  "description": "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with answer codes and item codes. German (de-DE) primary text from the validated PCOR-MII Item Level Dictionary (MASTER_3EntitiesOverview.xlsx). Ordinal scoring weights are applied at the Questionnaire level via ordinalValue extensions. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed.",
+  "description": "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed.",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
   "concept": [
     {
       "code": "whodas12-answer-0",
-      "display": "keine"
+      "display": "None",
+      "designation": [
+        {
+          "language": "de",
+          "value": "keine"
+        }
+      ],
+      "property": [
+        {
+          "code": "ordinalValue",
+          "valueDecimal": 0
+        }
+      ]
     },
     {
       "code": "whodas12-answer-1",
-      "display": "geringe"
+      "display": "Mild",
+      "designation": [
+        {
+          "language": "de",
+          "value": "geringe"
+        }
+      ],
+      "property": [
+        {
+          "code": "ordinalValue",
+          "valueDecimal": 1
+        }
+      ]
     },
     {
       "code": "whodas12-answer-2",
-      "display": "mäßige"
+      "display": "Moderate",
+      "designation": [
+        {
+          "language": "de",
+          "value": "mäßige"
+        }
+      ],
+      "property": [
+        {
+          "code": "ordinalValue",
+          "valueDecimal": 2
+        }
+      ]
     },
     {
       "code": "whodas12-answer-3",
-      "display": "starke"
+      "display": "Severe",
+      "designation": [
+        {
+          "language": "de",
+          "value": "starke"
+        }
+      ],
+      "property": [
+        {
+          "code": "ordinalValue",
+          "valueDecimal": 3
+        }
+      ]
     },
     {
       "code": "whodas12-answer-4",
-      "display": "sehr starke/nicht möglich"
+      "display": "Extreme or cannot do",
+      "designation": [
+        {
+          "language": "de",
+          "value": "sehr starke/nicht möglich"
+        }
+      ],
+      "property": [
+        {
+          "code": "ordinalValue",
+          "valueDecimal": 4
+        }
+      ]
     },
     {
       "code": "whodas12-q01",
-      "display": "längere Zeit (ca. 30 min) zu stehen?"
+      "display": "Standing for long periods such as 30 minutes?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "längere Zeit (ca. 30 min) zu stehen?"
+        }
+      ]
     },
     {
       "code": "whodas12-q02",
-      "display": "Ihren Haushaltspflichten nachzukommen?"
+      "display": "Taking care of your household responsibilities?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Ihren Haushaltspflichten nachzukommen?"
+        }
+      ]
     },
     {
       "code": "whodas12-q03",
-      "display": "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+      "display": "Learning a new task, for example, learning how to get to a new place?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+        }
+      ]
     },
     {
       "code": "whodas12-q04",
-      "display": "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+      "display": "Joining in community activities (for example, festivities, religious or other activities) in the same way as anyone else can?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+        }
+      ]
     },
     {
       "code": "whodas12-q05",
-      "display": "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+      "display": "Being emotionally affected by your health problems?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+        }
+      ]
     },
     {
       "code": "whodas12-q06",
-      "display": "Sich auf etwas für 10 Minuten zu konzentrieren?"
+      "display": "Concentrating on doing something for ten minutes?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Sich auf etwas für 10 Minuten zu konzentrieren?"
+        }
+      ]
     },
     {
       "code": "whodas12-q07",
-      "display": "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+      "display": "Walking a long distance such as a kilometre?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+        }
+      ]
     },
     {
       "code": "whodas12-q08",
-      "display": "Ihren gesamten Körper zu waschen?"
+      "display": "Washing your whole body?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Ihren gesamten Körper zu waschen?"
+        }
+      ]
     },
     {
       "code": "whodas12-q09",
-      "display": "sich anzuziehen?"
+      "display": "Getting dressed?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "sich anzuziehen?"
+        }
+      ]
     },
     {
       "code": "whodas12-q10",
-      "display": "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+      "display": "Dealing with people you do not know?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+        }
+      ]
     },
     {
       "code": "whodas12-q11",
-      "display": "Eine Freundschaft aufrechtzuerhalten?"
+      "display": "Maintaining a friendship?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Eine Freundschaft aufrechtzuerhalten?"
+        }
+      ]
     },
     {
       "code": "whodas12-q12",
-      "display": "Bei der Bewältigung des Arbeits-/Schulalltags?"
+      "display": "Your day-to-day work/school?",
+      "designation": [
+        {
+          "language": "de",
+          "value": "Bei der Bewältigung des Arbeits-/Schulalltags?"
+        }
+      ]
     }
   ],
   "version": "2026.4.1",
   "experimental": true,
   "caseSensitive": true,
+  "language": "en",
+  "property": [
+    {
+      "code": "ordinalValue",
+      "uri": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+      "description": "Numerical ordinal value (0-4) for SDC calculatedExpression scoring via .ordinal().sum()",
+      "type": "decimal"
+    }
+  ],
   "count": 17
 }

--- a/fsh-generated/resources/Observation-mii-exa-pro-whodas12-score-simple-sum.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-whodas12-score-simple-sum.json
@@ -1,0 +1,50 @@
+{
+  "resourceType": "Observation",
+  "id": "mii-exa-pro-whodas12-score-simple-sum",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+    ]
+  },
+  "category": [
+    {
+      "coding": [
+        {
+          "code": "survey",
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+          "display": "Survey"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "code": "715823002",
+        "system": "http://snomed.info/sct",
+        "display": "WHODAS (World Health Organization Disability Assessment Schedule) 2.0 score"
+      },
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-score-catalogue",
+        "code": "whodas12-simple-sum",
+        "display": "WHODAS 2.0 12-Item Simple Sum Score (0-48)"
+      }
+    ]
+  },
+  "subject": {
+    "reference": "Patient/mii-exa-pro-patient"
+  },
+  "valueQuantity": {
+    "value": 24,
+    "unit": "{score}",
+    "system": "http://unitsofmeasure.org",
+    "code": "{score}"
+  },
+  "derivedFrom": [
+    {
+      "reference": "QuestionnaireResponse/mii-exa-pro-whodas12-response-01"
+    }
+  ],
+  "status": "final",
+  "effectiveDateTime": "2026-02-01"
+}

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-whodas12-simple-sum.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-whodas12-simple-sum.json
@@ -1,0 +1,82 @@
+{
+  "resourceType": "ObservationDefinition",
+  "id": "mii-obsdef-pro-score-whodas12-simple-sum",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+    ]
+  },
+  "extension": [
+    {
+      "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
+      "valueString": "2026.4.1"
+    }
+  ],
+  "category": [
+    {
+      "coding": [
+        {
+          "code": "survey",
+          "system": "http://terminology.hl7.org/CodeSystem/observation-category"
+        }
+      ]
+    }
+  ],
+  "code": {
+    "coding": [
+      {
+        "system": "http://snomed.info/sct",
+        "code": "715823002",
+        "display": "WHODAS (World Health Organization Disability Assessment Schedule) 2.0 score"
+      },
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-score-catalogue",
+        "code": "whodas12-simple-sum",
+        "display": "WHODAS 2.0 12-Item Simple Sum Score (0-48)"
+      }
+    ]
+  },
+  "permittedDataType": [
+    "Quantity"
+  ],
+  "quantitativeDetails": {
+    "unit": {
+      "coding": [
+        {
+          "code": "{score}",
+          "system": "http://unitsofmeasure.org",
+          "display": "score"
+        }
+      ]
+    },
+    "decimalPrecision": 0
+  },
+  "qualifiedInterval": [
+    {
+      "range": {
+        "low": {
+          "value": 0
+        },
+        "high": {
+          "value": 48
+        },
+        "extension": [
+          {
+            "valueCodeableConcept": {
+              "coding": [
+                {
+                  "system": "http://terminology.hl7.org/CodeSystem/measure-improvement-notation",
+                  "code": "decrease"
+                }
+              ],
+              "text": "Higher score indicates greater disability"
+            },
+            "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-score-score-health-correlation"
+          }
+        ]
+      },
+      "category": "absolute"
+    }
+  ],
+  "multipleResultsAllowed": false
+}

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
@@ -7,8 +7,8 @@
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12",
-  "title": "WHO Disability Assessment Schedule 2.0 - 12-Item (WHODAS-12)",
-  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12) - Metadata-only reference implementation. Full item content is not reproduced because electronic reproduction of WHODAS 2.0 requires written permission from WHO.",
+  "title": "MII QST PRO WHODAS 2.0 12-Item",
+  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). German primary content from the validated PCOR-MII Item Level Dictionary. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed.",
   "code": [
     {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-questionnaire-catalogue",
@@ -21,11 +21,11 @@
       "extension": [
         {
           "url": "displayable",
-          "valueBoolean": false
+          "valueBoolean": true
         },
         {
           "url": "collectable",
-          "valueBoolean": false
+          "valueBoolean": true
         },
         {
           "url": "calculatable",
@@ -41,18 +41,1013 @@
         }
       ],
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-questionnaire-capabilities"
+    },
+    {
+      "valueExpression": {
+        "name": "simpleSum",
+        "language": "text/fhirpath",
+        "expression": "%resource.item.where(linkId.matches('^whodas-whodas12-q(0[1-9]|1[0-2])$')).answer.value.ordinal().sum()"
+      },
+      "url": "http://hl7.org/fhir/StructureDefinition/variable"
     }
   ],
   "item": [
     {
-      "linkId": "WHODAS12.Notice",
+      "linkId": "WHODAS12.Description",
       "type": "display",
-      "text": "This questionnaire (WHODAS 2.0, 12-item) is reproduced only as a metadata reference. The item text is not included because electronic reproduction of WHODAS 2.0 requires written permission from the World Health Organization. To license WHODAS 2.0 for an electronic data capture system, see the WHO Classifications licensing process."
+      "text": "Wie viele Schwierigkeiten hatten Sie in den letzten 30 Tagen:"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q01",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q01",
+      "type": "choice",
+      "prefix": "1",
+      "text": "längere Zeit (ca. 30 min) zu stehen?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q02",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q02",
+      "type": "choice",
+      "prefix": "2",
+      "text": "Ihren Haushaltspflichten nachzukommen?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q03",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q03",
+      "type": "choice",
+      "prefix": "3",
+      "text": "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q04",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q04",
+      "type": "choice",
+      "prefix": "4",
+      "text": "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q05",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q05",
+      "type": "choice",
+      "prefix": "5",
+      "text": "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q06",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q06",
+      "type": "choice",
+      "prefix": "6",
+      "text": "Sich auf etwas für 10 Minuten zu konzentrieren?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q07",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q07",
+      "type": "choice",
+      "prefix": "7",
+      "text": "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q08",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q08",
+      "type": "choice",
+      "prefix": "8",
+      "text": "Ihren gesamten Körper zu waschen?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q09",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q09",
+      "type": "choice",
+      "prefix": "9",
+      "text": "sich anzuziehen?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q10",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q10",
+      "type": "choice",
+      "prefix": "10",
+      "text": "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q11",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q11",
+      "type": "choice",
+      "prefix": "11",
+      "text": "Eine Freundschaft aufrechtzuerhalten?"
+    },
+    {
+      "code": [
+        {
+          "code": "whodas12-q12",
+          "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+        }
+      ],
+      "answerOption": [
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 0
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-0",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "keine"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 1
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-1",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "geringe"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 2
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 3
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-3",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "starke"
+          }
+        },
+        {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
+              "valueDecimal": 4
+            }
+          ],
+          "valueCoding": {
+            "code": "whodas12-answer-4",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "sehr starke/nicht möglich"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q12",
+      "type": "choice",
+      "prefix": "12",
+      "text": "Bei der Bewältigung des Arbeits-/Schulalltags?"
+    },
+    {
+      "extension": [
+        {
+          "valueExpression": {
+            "name": "whodas12SimpleSum",
+            "language": "text/fhirpath",
+            "expression": "%simpleSum"
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-calculatedExpression"
+        },
+        {
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observationExtract",
+          "valueBoolean": true
+        },
+        {
+          "valueCoding": {
+            "system": "http://unitsofmeasure.org",
+            "code": "{score}"
+          },
+          "url": "http://hl7.org/fhir/StructureDefinition/questionnaire-unit"
+        },
+        {
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "http://terminology.hl7.org/CodeSystem/observation-category",
+                "code": "survey"
+              }
+            ]
+          },
+          "url": "http://hl7.org/fhir/uv/sdc/StructureDefinition/sdc-questionnaire-observation-extract-category"
+        }
+      ],
+      "linkId": "whodas-whodas12-score-simple-sum",
+      "type": "decimal",
+      "prefix": "Summenwert",
+      "readOnly": true,
+      "text": "WHODAS 2.0 12-Item Summenwert (Simple Sum, 0-48)"
     }
   ],
   "version": "2026.4.1",
   "status": "active",
   "experimental": true,
-  "language": "en",
-  "copyright": "WHODAS 2.0 © World Health Organization 2010. Reproduced/used only by reference. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule)."
+  "language": "de",
+  "copyright": "WHODAS 2.0 © World Health Organization 2010. Reproduced for review only. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule). NOT for publication until licensing is confirmed. German item content from the validated PCOR-MII Item Level Dictionary."
 }

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
@@ -8,7 +8,7 @@
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12",
   "title": "MII QST PRO WHODAS 2.0 12-Item",
-  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). German primary content from the validated PCOR-MII Item Level Dictionary. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed.",
+  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed.",
   "code": [
     {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-questionnaire-catalogue",
@@ -55,7 +55,24 @@
     {
       "linkId": "WHODAS12.Description",
       "type": "display",
-      "text": "Wie viele Schwierigkeiten hatten Sie in den letzten 30 Tagen:"
+      "text": "In the past 30 days, how much difficulty did you have in:",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Wie viele Schwierigkeiten hatten Sie in den letzten 30 Tagen:"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
     },
     {
       "code": [
@@ -64,77 +81,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q01",
       "type": "choice",
       "prefix": "1",
-      "text": "längere Zeit (ca. 30 min) zu stehen?"
+      "text": "Standing for long periods such as 30 minutes?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "längere Zeit (ca. 30 min) zu stehen?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -143,77 +111,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q02",
       "type": "choice",
       "prefix": "2",
-      "text": "Ihren Haushaltspflichten nachzukommen?"
+      "text": "Taking care of your household responsibilities?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Ihren Haushaltspflichten nachzukommen?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -222,77 +141,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q03",
       "type": "choice",
       "prefix": "3",
-      "text": "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+      "text": "Learning a new task, for example, learning how to get to a new place?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -301,77 +171,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q04",
       "type": "choice",
       "prefix": "4",
-      "text": "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+      "text": "Joining in community activities (for example, festivities, religious or other activities) in the same way as anyone else can?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -380,77 +201,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q05",
       "type": "choice",
       "prefix": "5",
-      "text": "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+      "text": "Being emotionally affected by your health problems?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -459,77 +231,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q06",
       "type": "choice",
       "prefix": "6",
-      "text": "Sich auf etwas für 10 Minuten zu konzentrieren?"
+      "text": "Concentrating on doing something for ten minutes?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Sich auf etwas für 10 Minuten zu konzentrieren?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -538,77 +261,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q07",
       "type": "choice",
       "prefix": "7",
-      "text": "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+      "text": "Walking a long distance such as a kilometre?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -617,77 +291,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q08",
       "type": "choice",
       "prefix": "8",
-      "text": "Ihren gesamten Körper zu waschen?"
+      "text": "Washing your whole body?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Ihren gesamten Körper zu waschen?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -696,77 +321,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q09",
       "type": "choice",
       "prefix": "9",
-      "text": "sich anzuziehen?"
+      "text": "Getting dressed?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "sich anzuziehen?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -775,77 +351,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q10",
       "type": "choice",
       "prefix": "10",
-      "text": "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+      "text": "Dealing with people you do not know?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -854,77 +381,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q11",
       "type": "choice",
       "prefix": "11",
-      "text": "Eine Freundschaft aufrechtzuerhalten?"
+      "text": "Maintaining a friendship?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Eine Freundschaft aufrechtzuerhalten?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "code": [
@@ -933,77 +411,28 @@
           "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
         }
       ],
-      "answerOption": [
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 0
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-0",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "keine"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 1
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-1",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "geringe"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 2
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-2",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 3
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-3",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "starke"
-          }
-        },
-        {
-          "extension": [
-            {
-              "url": "http://hl7.org/fhir/StructureDefinition/ordinalValue",
-              "valueDecimal": 4
-            }
-          ],
-          "valueCoding": {
-            "code": "whodas12-answer-4",
-            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "sehr starke/nicht möglich"
-          }
-        }
-      ],
       "linkId": "whodas-whodas12-q12",
       "type": "choice",
       "prefix": "12",
-      "text": "Bei der Bewältigung des Arbeits-/Schulalltags?"
+      "text": "Your day-to-day work/school?",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "Bei der Bewältigung des Arbeits-/Schulalltags?"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      },
+      "answerValueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
     },
     {
       "extension": [
@@ -1040,14 +469,31 @@
       ],
       "linkId": "whodas-whodas12-score-simple-sum",
       "type": "decimal",
-      "prefix": "Summenwert",
+      "prefix": "Sum score",
       "readOnly": true,
-      "text": "WHODAS 2.0 12-Item Summenwert (Simple Sum, 0-48)"
+      "text": "WHODAS 2.0 12-Item simple sum score (0-48)",
+      "_text": {
+        "extension": [
+          {
+            "extension": [
+              {
+                "url": "lang",
+                "valueCode": "de"
+              },
+              {
+                "url": "content",
+                "valueString": "WHODAS 2.0 12-Item Summenwert (Simple Sum, 0-48)"
+              }
+            ],
+            "url": "http://hl7.org/fhir/StructureDefinition/translation"
+          }
+        ]
+      }
     }
   ],
   "version": "2026.4.1",
   "status": "active",
   "experimental": true,
-  "language": "de",
+  "language": "en",
   "copyright": "WHODAS 2.0 © World Health Organization 2010. Reproduced for review only. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule). NOT for publication until licensing is confirmed. German item content from the validated PCOR-MII Item Level Dictionary."
 }

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
@@ -8,7 +8,7 @@
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12",
   "title": "MII QST PRO WHODAS 2.0 12-Item",
-  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed.",
+  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations (validated PCOR-MII wording). WHODAS 2.0 © WHO 2010 — see copyright for licensing conditions (a WHO licence is required for electronic/data-capture use).",
   "code": [
     {
       "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-questionnaire-catalogue",
@@ -204,7 +204,7 @@
       "linkId": "whodas-whodas12-q05",
       "type": "choice",
       "prefix": "5",
-      "text": "Being emotionally affected by your health problems?",
+      "text": "How much have you been emotionally affected by your health problems?",
       "_text": {
         "extension": [
           {
@@ -495,5 +495,5 @@
   "status": "active",
   "experimental": true,
   "language": "en",
-  "copyright": "WHODAS 2.0 © World Health Organization 2010. Reproduced for review only. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule). NOT for publication until licensing is confirmed. German item content from the validated PCOR-MII Item Level Dictionary."
+  "copyright": "WHODAS 2.0 © World Health Organization 2010 (Measuring Health and Disability: Manual for WHODAS 2.0, ISBN 9789241547598). WHO permits clinicians to reproduce WHODAS 2.0 for use with their own patients free of charge. Any other use — including reproduction in an electronic data capture system — requires a licence agreement (free of charge for non-commercial use) via the WHO Classifications licensing process; translations require WHO permission. The German item wording follows the validated PCOR-MII Item Level Dictionary. Only the MII-authored FHIR content (profiles, codes, scoring) is licensed CC0; the WHODAS 2.0 item text remains © World Health Organization."
 }

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
@@ -1,0 +1,58 @@
+{
+  "resourceType": "Questionnaire",
+  "id": "mii-qst-pro-whodas-whodas12",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+    ]
+  },
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12",
+  "title": "WHO Disability Assessment Schedule 2.0 - 12-Item (WHODAS-12)",
+  "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12) - Metadata-only reference implementation. Full item content is not reproduced because electronic reproduction of WHODAS 2.0 requires written permission from WHO.",
+  "code": [
+    {
+      "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-questionnaire-catalogue",
+      "code": "whodas-whodas12",
+      "display": "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
+    }
+  ],
+  "extension": [
+    {
+      "extension": [
+        {
+          "url": "displayable",
+          "valueBoolean": false
+        },
+        {
+          "url": "collectable",
+          "valueBoolean": false
+        },
+        {
+          "url": "calculatable",
+          "valueBoolean": true
+        },
+        {
+          "url": "extractable",
+          "valueBoolean": true
+        },
+        {
+          "url": "domainAligned",
+          "valueBoolean": true
+        }
+      ],
+      "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-questionnaire-capabilities"
+    }
+  ],
+  "item": [
+    {
+      "linkId": "WHODAS12.Notice",
+      "type": "display",
+      "text": "This questionnaire (WHODAS 2.0, 12-item) is reproduced only as a metadata reference. The item text is not included because electronic reproduction of WHODAS 2.0 requires written permission from the World Health Organization. To license WHODAS 2.0 for an electronic data capture system, see the WHO Classifications licensing process."
+    }
+  ],
+  "version": "2026.4.1",
+  "status": "active",
+  "experimental": true,
+  "language": "en",
+  "copyright": "WHODAS 2.0 © World Health Organization 2010. Reproduced/used only by reference. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule)."
+}

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
@@ -1,0 +1,169 @@
+{
+  "resourceType": "QuestionnaireResponse",
+  "id": "mii-exa-pro-whodas12-response-01",
+  "meta": {
+    "profile": [
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+    ]
+  },
+  "subject": {
+    "reference": "Patient/mii-exa-pro-patient"
+  },
+  "item": [
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q01"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q02"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q03"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q04"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q05"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q06"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q07"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q08"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q09"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q10"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q11"
+    },
+    {
+      "answer": [
+        {
+          "valueCoding": {
+            "code": "whodas12-answer-2",
+            "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+            "display": "mäßige"
+          }
+        }
+      ],
+      "linkId": "whodas-whodas12-q12"
+    },
+    {
+      "answer": [
+        {
+          "valueDecimal": 24
+        }
+      ],
+      "linkId": "whodas-whodas12-score-simple-sum"
+    }
+  ],
+  "questionnaire": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12",
+  "status": "completed",
+  "authored": "2026-02-01"
+}

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
@@ -16,7 +16,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -28,7 +28,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -40,7 +40,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -52,7 +52,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -64,7 +64,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -76,7 +76,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -88,7 +88,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -100,7 +100,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -112,7 +112,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -124,7 +124,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -136,7 +136,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],
@@ -148,7 +148,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "mäßige"
+            "display": "Moderate"
           }
         }
       ],

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
@@ -4,7 +4,7 @@
   "name": "MII_VS_PRO_WHODAS_12_Answer_List",
   "id": "mii-vs-pro-whodas-12-answer-list",
   "title": "MII VS PRO WHODAS 2.0 12-Item Answer List",
-  "description": "5-point response scale for all WHODAS-12 items (0 = keine, 1 = geringe, 2 = mäßige, 3 = starke, 4 = sehr starke/nicht möglich)",
+  "description": "5-point response scale for all WHODAS-12 items (0 = None, 1 = Mild, 2 = Moderate, 3 = Severe, 4 = Extreme or cannot do). MII-controlled for reliable ordinal() score calculation; German labels via designations on mii-cs-pro-whodas-12.",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list",
   "version": "2026.4.1",
   "experimental": true,

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
@@ -31,5 +31,77 @@
         ]
       }
     ]
+  },
+  "expansion": {
+    "identifier": "urn:uuid:mii-pro-expansion-1783407037498",
+    "timestamp": "2026-07-07T06:50:37.468Z",
+    "total": 5,
+    "parameter": [
+      {
+        "name": "mii-pro-version",
+        "valueString": "2026.4.1"
+      },
+      {
+        "name": "expandedAt",
+        "valueDateTime": "2026-07-07T06:50:37.468Z"
+      }
+    ],
+    "contains": [
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+        "code": "whodas12-answer-0",
+        "display": "None",
+        "designation": [
+          {
+            "language": "de",
+            "value": "keine"
+          }
+        ]
+      },
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+        "code": "whodas12-answer-1",
+        "display": "Mild",
+        "designation": [
+          {
+            "language": "de",
+            "value": "geringe"
+          }
+        ]
+      },
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+        "code": "whodas12-answer-2",
+        "display": "Moderate",
+        "designation": [
+          {
+            "language": "de",
+            "value": "mäßige"
+          }
+        ]
+      },
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+        "code": "whodas12-answer-3",
+        "display": "Severe",
+        "designation": [
+          {
+            "language": "de",
+            "value": "starke"
+          }
+        ]
+      },
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+        "code": "whodas12-answer-4",
+        "display": "Extreme or cannot do",
+        "designation": [
+          {
+            "language": "de",
+            "value": "sehr starke/nicht möglich"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
@@ -1,0 +1,35 @@
+{
+  "resourceType": "ValueSet",
+  "status": "active",
+  "name": "MII_VS_PRO_WHODAS_12_Answer_List",
+  "id": "mii-vs-pro-whodas-12-answer-list",
+  "title": "MII VS PRO WHODAS 2.0 12-Item Answer List",
+  "description": "5-point response scale for all WHODAS-12 items (0 = keine, 1 = geringe, 2 = mäßige, 3 = starke, 4 = sehr starke/nicht möglich)",
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list",
+  "version": "2026.4.1",
+  "experimental": true,
+  "compose": {
+    "include": [
+      {
+        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
+        "concept": [
+          {
+            "code": "whodas12-answer-0"
+          },
+          {
+            "code": "whodas12-answer-1"
+          },
+          {
+            "code": "whodas12-answer-2"
+          },
+          {
+            "code": "whodas12-answer-3"
+          },
+          {
+            "code": "whodas12-answer-4"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -16,6 +16,7 @@ Alias: $mii-qst-pro-promis-depression-sf4a = https://www.medizininformatik-initi
 Alias: $mii-qst-pro-dass-dass21 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-dass-dass21
 Alias: $mii-cs-pro-dass-21 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-dass-21
 Alias: $mii-cs-pro-pro-ctcae = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-pro-ctcae
+Alias: $mii-qst-pro-whodas-whodas12 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12
 Alias: $mii-vs-pro-dass-21-answer-list = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-dass-21-answer-list
 // HL7
 Alias: $hl7-concept-properties = http://hl7.org/fhir/concept-properties

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -17,6 +17,8 @@ Alias: $mii-qst-pro-dass-dass21 = https://www.medizininformatik-initiative.de/fh
 Alias: $mii-cs-pro-dass-21 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-dass-21
 Alias: $mii-cs-pro-pro-ctcae = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-pro-ctcae
 Alias: $mii-qst-pro-whodas-whodas12 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12
+Alias: $mii-cs-pro-whodas-12 = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12
+Alias: $mii-vs-pro-whodas-12-answer-list = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list
 Alias: $mii-vs-pro-dass-21-answer-list = https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-dass-21-answer-list
 // HL7
 Alias: $hl7-concept-properties = http://hl7.org/fhir/concept-properties

--- a/input/fsh/definitions/whodas/mii-cs-pro-whodas-12.fsh
+++ b/input/fsh/definitions/whodas/mii-cs-pro-whodas-12.fsh
@@ -1,0 +1,41 @@
+CodeSystem: MII_CS_PRO_WHODAS_12
+Id: mii-cs-pro-whodas-12
+Title: "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes"
+Description: "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with answer codes and item codes. German (de-DE) primary text from the validated PCOR-MII Item Level Dictionary (MASTER_3EntitiesOverview.xlsx). Ordinal scoring weights are applied at the Questionnaire level via ordinalValue extensions. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed."
+* ^url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
+* insert PR_CS_VS_Version
+* ^status = #active
+* ^experimental = true
+* ^caseSensitive = true
+* ^content = #complete
+
+// ============================================================================
+// Answer codes: 5-point ordinal scale (0-4), shared by all 12 items
+// German primary text per PCOR-MII validated dictionary.
+// Scoring weights applied at the Questionnaire level via ordinalValue.
+// ============================================================================
+
+* #whodas12-answer-0 "keine"
+* #whodas12-answer-1 "geringe"
+* #whodas12-answer-2 "mäßige"
+* #whodas12-answer-3 "starke"
+* #whodas12-answer-4 "sehr starke/nicht möglich"
+
+// ============================================================================
+// Item codes: 12 items across 6 ICF domains
+// (Cognition, Mobility, Self-care, Getting along, Life activities, Participation)
+// German primary text per PCOR-MII validated dictionary (variable IDs WHODAS12_01..12).
+// ============================================================================
+
+* #whodas12-q01 "längere Zeit (ca. 30 min) zu stehen?"
+* #whodas12-q02 "Ihren Haushaltspflichten nachzukommen?"
+* #whodas12-q03 "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+* #whodas12-q04 "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+* #whodas12-q05 "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+* #whodas12-q06 "Sich auf etwas für 10 Minuten zu konzentrieren?"
+* #whodas12-q07 "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+* #whodas12-q08 "Ihren gesamten Körper zu waschen?"
+* #whodas12-q09 "sich anzuziehen?"
+* #whodas12-q10 "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+* #whodas12-q11 "Eine Freundschaft aufrechtzuerhalten?"
+* #whodas12-q12 "Bei der Bewältigung des Arbeits-/Schulalltags?"

--- a/input/fsh/definitions/whodas/mii-cs-pro-whodas-12.fsh
+++ b/input/fsh/definitions/whodas/mii-cs-pro-whodas-12.fsh
@@ -1,41 +1,113 @@
+// ============================================================================
+// WHODAS 2.0 12-Item CodeSystem (item codes + answer scale)
+// ============================================================================
+// WHO Disability Assessment Schedule 2.0, 12-item self-administered version.
+//
+// Design (consistent with PHQ-15): English-primary displays with German
+// designations (de). The 5 answer concepts (whodas12-answer-0..4) carry an
+// ordinalValue property (0-4) so that SDC .ordinal() can resolve weights when
+// this CS is expanded via mii-vs-pro-whodas-12-answer-list as answerValueSet.
+// Note: in-form .ordinal() resolution from answerValueSet is engine-dependent;
+// server-side scoring via CQL/StructureMap is tracked separately.
+//
+// German item text and answer labels from the validated PCOR-MII Item Level
+// Dictionary (MASTER_3EntitiesOverview.xlsx). English item wording follows the
+// official WHO WHODAS 2.0 12-item self-administered form.
+//
+// !!! LICENSING - NOT FOR PUBLICATION UNTIL CONFIRMED !!!
+// WHODAS 2.0 © World Health Organization 2010. Electronic reproduction requires
+// written WHO permission; reproduced here for review only.
+// ============================================================================
+
 CodeSystem: MII_CS_PRO_WHODAS_12
 Id: mii-cs-pro-whodas-12
 Title: "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes"
-Description: "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with answer codes and item codes. German (de-DE) primary text from the validated PCOR-MII Item Level Dictionary (MASTER_3EntitiesOverview.xlsx). Ordinal scoring weights are applied at the Questionnaire level via ordinalValue extensions. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed."
+Description: "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed."
 * ^url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
 * insert PR_CS_VS_Version
 * ^status = #active
 * ^experimental = true
 * ^caseSensitive = true
 * ^content = #complete
+* ^language = #en
+
+// ordinalValue property for SDC ordinal scoring (uri matches HL7 ordinalValue extension)
+* ^property[+].code = #ordinalValue
+* ^property[=].uri = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* ^property[=].description = "Numerical ordinal value (0-4) for SDC calculatedExpression scoring via .ordinal().sum()"
+* ^property[=].type = #decimal
 
 // ============================================================================
 // Answer codes: 5-point ordinal scale (0-4), shared by all 12 items
-// German primary text per PCOR-MII validated dictionary.
-// Scoring weights applied at the Questionnaire level via ordinalValue.
+// English primary display, German designation, ordinalValue weight.
 // ============================================================================
 
-* #whodas12-answer-0 "keine"
-* #whodas12-answer-1 "geringe"
-* #whodas12-answer-2 "mäßige"
-* #whodas12-answer-3 "starke"
-* #whodas12-answer-4 "sehr starke/nicht möglich"
+* #whodas12-answer-0 "None"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "keine"
+  * ^property[+].code = #ordinalValue
+  * ^property[=].valueDecimal = 0
+* #whodas12-answer-1 "Mild"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "geringe"
+  * ^property[+].code = #ordinalValue
+  * ^property[=].valueDecimal = 1
+* #whodas12-answer-2 "Moderate"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "mäßige"
+  * ^property[+].code = #ordinalValue
+  * ^property[=].valueDecimal = 2
+* #whodas12-answer-3 "Severe"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "starke"
+  * ^property[+].code = #ordinalValue
+  * ^property[=].valueDecimal = 3
+* #whodas12-answer-4 "Extreme or cannot do"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "sehr starke/nicht möglich"
+  * ^property[+].code = #ordinalValue
+  * ^property[=].valueDecimal = 4
 
 // ============================================================================
 // Item codes: 12 items across 6 ICF domains
 // (Cognition, Mobility, Self-care, Getting along, Life activities, Participation)
-// German primary text per PCOR-MII validated dictionary (variable IDs WHODAS12_01..12).
+// English primary display (WHO wording), German designation (PCOR-MII dictionary).
+// Variable IDs WHODAS12_01..12.
 // ============================================================================
 
-* #whodas12-q01 "längere Zeit (ca. 30 min) zu stehen?"
-* #whodas12-q02 "Ihren Haushaltspflichten nachzukommen?"
-* #whodas12-q03 "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
-* #whodas12-q04 "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
-* #whodas12-q05 "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
-* #whodas12-q06 "Sich auf etwas für 10 Minuten zu konzentrieren?"
-* #whodas12-q07 "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
-* #whodas12-q08 "Ihren gesamten Körper zu waschen?"
-* #whodas12-q09 "sich anzuziehen?"
-* #whodas12-q10 "Im Umgang mit anderen Personen, die Sie nicht kennen?"
-* #whodas12-q11 "Eine Freundschaft aufrechtzuerhalten?"
-* #whodas12-q12 "Bei der Bewältigung des Arbeits-/Schulalltags?"
+* #whodas12-q01 "Standing for long periods such as 30 minutes?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "längere Zeit (ca. 30 min) zu stehen?"
+* #whodas12-q02 "Taking care of your household responsibilities?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Ihren Haushaltspflichten nachzukommen?"
+* #whodas12-q03 "Learning a new task, for example, learning how to get to a new place?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+* #whodas12-q04 "Joining in community activities (for example, festivities, religious or other activities) in the same way as anyone else can?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+* #whodas12-q05 "Being emotionally affected by your health problems?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+* #whodas12-q06 "Concentrating on doing something for ten minutes?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Sich auf etwas für 10 Minuten zu konzentrieren?"
+* #whodas12-q07 "Walking a long distance such as a kilometre?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+* #whodas12-q08 "Washing your whole body?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Ihren gesamten Körper zu waschen?"
+* #whodas12-q09 "Getting dressed?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "sich anzuziehen?"
+* #whodas12-q10 "Dealing with people you do not know?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+* #whodas12-q11 "Maintaining a friendship?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Eine Freundschaft aufrechtzuerhalten?"
+* #whodas12-q12 "Your day-to-day work/school?"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Bei der Bewältigung des Arbeits-/Schulalltags?"

--- a/input/fsh/definitions/whodas/mii-cs-pro-whodas-12.fsh
+++ b/input/fsh/definitions/whodas/mii-cs-pro-whodas-12.fsh
@@ -14,15 +14,16 @@
 // Dictionary (MASTER_3EntitiesOverview.xlsx). English item wording follows the
 // official WHO WHODAS 2.0 12-item self-administered form.
 //
-// !!! LICENSING - NOT FOR PUBLICATION UNTIL CONFIRMED !!!
-// WHODAS 2.0 © World Health Organization 2010. Electronic reproduction requires
-// written WHO permission; reproduced here for review only.
+// LICENSING — WHODAS 2.0 © World Health Organization 2010. Free of charge;
+// electronic/data-capture use requires a WHO licence agreement (free for
+// non-commercial use) via the WHO Classifications licensing process. Only the
+// MII-authored FHIR content is CC0; the WHODAS 2.0 text remains © WHO.
 // ============================================================================
 
 CodeSystem: MII_CS_PRO_WHODAS_12
 Id: mii-cs-pro-whodas-12
 Title: "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes"
-Description: "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. NOTE: WHODAS 2.0 © WHO 2010 - electronic reproduction requires written WHO permission; reproduced here for review only, NOT for publication until licensing is confirmed."
+Description: "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. WHODAS 2.0 © WHO 2010; electronic use requires a WHO licence (see copyright)."
 * ^url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12"
 * insert PR_CS_VS_Version
 * ^status = #active
@@ -30,6 +31,7 @@ Description: "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item
 * ^caseSensitive = true
 * ^content = #complete
 * ^language = #en
+* ^copyright = "WHODAS 2.0 © World Health Organization 2010. Scale/item text used under WHO terms; electronic or data-capture use requires a WHO licence agreement (free of charge for non-commercial use) via the WHO Classifications licensing process. MII-authored FHIR content is licensed CC0."
 
 // ordinalValue property for SDC ordinal scoring (uri matches HL7 ordinalValue extension)
 * ^property[+].code = #ordinalValue

--- a/input/fsh/definitions/whodas/mii-obsdef-pro-score-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-obsdef-pro-score-whodas12.fsh
@@ -1,0 +1,48 @@
+// ============================================================================
+// WHODAS 2.0 12-Item ObservationDefinition
+// ============================================================================
+// One score definition for the WHO Disability Assessment Schedule 2.0,
+// 12-item self-administered version.
+//
+// Simple scoring (implemented): sum of the 12 item scores (each 0-4), range
+// 0-48, where a higher score indicates more disability. This is WHO's "simple
+// scoring" method (scores are added without recoding or collapsing of
+// categories). The corresponding calculated-expression FHIRPath would be
+//   %resource.item.where(linkId.matches('^whodas-whodas12-q(01..12)$'))
+//       .answer.value.ordinal().sum()
+// but is not embedded in the Questionnaire because the WHODAS-12 items are not
+// reproduced here for licensing reasons (see mii-qst-pro-whodas-whodas12).
+//
+// Complex / IRT-based scoring (deferred): WHO also defines a complex scoring
+// method based on item-response theory that differentially weights items and
+// rescales to 0-100. This is intentionally NOT implemented in this version and
+// is recorded as future work.
+//
+// SNOMED: code 715823002 "WHODAS (World Health Organization Disability
+// Assessment Schedule) 2.0 score" was obtained via web lookup but could NOT be
+// verified against a terminology server during implementation (Snowstorm
+// unavailable). Treat as provisional pending terminology-server confirmation.
+// ============================================================================
+
+Instance: mii-obsdef-pro-score-whodas12-simple-sum
+InstanceOf: mii-pr-pro-score-blueprint
+Title: "WHODAS 2.0 12-Item Simple Sum Score"
+Description: "Sum of the 12 WHODAS 2.0 item scores (each 0-4), range 0-48. Higher scores indicate greater disability. WHO simple scoring method; complex IRT-based scoring deferred to future work."
+Usage: #definition
+* insert ObsDefVersion
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint)
+
+* category.coding = http://terminology.hl7.org/CodeSystem/observation-category#survey
+// SNOMED code provisional / not server-verified - see header note
+* code.coding[snomed] = $SCT#715823002 "WHODAS (World Health Organization Disability Assessment Schedule) 2.0 score"
+* code.coding[mii] = $mii-cs-pro-score-catalogue#whodas12-simple-sum "WHODAS 2.0 12-Item Simple Sum Score (0-48)"
+* permittedDataType = #Quantity
+* multipleResultsAllowed = false
+* quantitativeDetails.unit = $UCUM#{score} "score"
+* quantitativeDetails.decimalPrecision = 0
+
+* qualifiedInterval.category = #absolute
+* qualifiedInterval.range.low.value = 0
+* qualifiedInterval.range.high.value = 48
+* qualifiedInterval.range.extension[ScoreHealthCorrelation].valueCodeableConcept.coding = http://terminology.hl7.org/CodeSystem/measure-improvement-notation#decrease
+* qualifiedInterval.range.extension[ScoreHealthCorrelation].valueCodeableConcept.text = "Higher score indicates greater disability"

--- a/input/fsh/definitions/whodas/mii-obsdef-pro-score-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-obsdef-pro-score-whodas12.fsh
@@ -19,9 +19,9 @@
 // is recorded as future work.
 //
 // SNOMED: code 715823002 "WHODAS (World Health Organization Disability
-// Assessment Schedule) 2.0 score" was obtained via web lookup but could NOT be
-// verified against a terminology server during implementation (Snowstorm
-// unavailable). Treat as provisional pending terminology-server confirmation.
+// Assessment Schedule) 2.0 score" — externally confirmed via the SNOMED CT
+// browser/FindACode; not yet verified against the local tx-server (Snowstorm
+// was unavailable during implementation). tx-server verification still pending.
 // ============================================================================
 
 Instance: mii-obsdef-pro-score-whodas12-simple-sum

--- a/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
@@ -146,7 +146,7 @@ Usage: #definition
 * item[5].type = #choice
 * item[5].prefix = "5"
 * item[5].code = $mii-cs-pro-whodas-12#whodas12-q05
-* item[5].text = "Being emotionally affected by your health problems?"
+* item[5].text = "How much have you been emotionally affected by your health problems?"
 * item[5].text.extension[0].url = $hl7-translation
 * item[5].text.extension[0].extension[0].url = "lang"
 * item[5].text.extension[0].extension[0].valueCode = #de

--- a/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
@@ -20,6 +20,11 @@
 // WHODAS-12 sum -> PROMIS Generic/Global Health conversion (ConceptMap/CQL),
 // not implemented in this version.
 //
+// Sources: WHO 2010 — Measuring Health and Disability: Manual for WHODAS 2.0
+// (ISBN 9789241547598). German validation: Kirchberger et al. 2014
+// (Population Health Metrics, doi:10.1186/s12963-014-0027-8, MONICA/KORA);
+// Saltychev et al. 2021 (systematic review, PMID 31335215).
+//
 // !!! LICENSING - NOT FOR PUBLICATION UNTIL CONFIRMED !!!
 // WHODAS 2.0 © World Health Organization 2010. WHO permits clinicians to
 // reproduce WHODAS 2.0 for use with their own patients, but ANY electronic

--- a/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
@@ -33,21 +33,21 @@
 // (Population Health Metrics, doi:10.1186/s12963-014-0027-8, MONICA/KORA);
 // Saltychev et al. 2021 (systematic review, PMID 31335215).
 //
-// !!! LICENSING - NOT FOR PUBLICATION UNTIL CONFIRMED !!!
-// WHODAS 2.0 © World Health Organization 2010. WHO permits clinicians to
-// reproduce WHODAS 2.0 for use with their own patients, but ANY electronic
-// use - including inclusion in an electronic data capture system or
-// reproduction "in any way" - requires WRITTEN PERMISSION from WHO via the
-// WHO Classifications licensing process. The item text is embedded here for
-// REVIEW/TESTING ONLY (per PCOR-MII direction, using their validated German
-// dictionary). This resource must NOT be published until WHO licensing (or a
-// CC0 equivalent) is confirmed.
+// LICENSING — WHODAS 2.0 © World Health Organization 2010. WHO permits
+// clinicians to reproduce WHODAS 2.0 for use with their own patients free of
+// charge; any other use — including inclusion in an electronic data capture
+// system — requires a WHO licence agreement (free for non-commercial use)
+// via the WHO Classifications licensing process, and translations require WHO
+// permission. The German item wording follows the validated PCOR-MII Item
+// Level Dictionary. Only the MII-authored FHIR content (structure, codes,
+// scoring) is CC0; the WHODAS 2.0 item text remains © WHO. These conditions
+// are recorded in the resource `copyright` element below.
 // ============================================================================
 
 Instance: mii-qst-pro-whodas-whodas12
 InstanceOf: mii-pr-pro-questionnaire
 Title: "MII QST PRO WHODAS 2.0 12-Item"
-Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed."
+Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations (validated PCOR-MII wording). WHODAS 2.0 © WHO 2010 — see copyright for licensing conditions (a WHO licence is required for electronic/data-capture use)."
 Usage: #definition
 * insert Version
 * insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire)
@@ -57,8 +57,7 @@ Usage: #definition
 * experimental = true
 * language = #en
 * code[mii] = $mii-cs-pro-questionnaire-catalogue#whodas-whodas12 "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
-
-* copyright = "WHODAS 2.0 © World Health Organization 2010. Reproduced for review only. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule). NOT for publication until licensing is confirmed. German item content from the validated PCOR-MII Item Level Dictionary."
+* copyright = "WHODAS 2.0 © World Health Organization 2010 (Measuring Health and Disability: Manual for WHODAS 2.0, ISBN 9789241547598). WHO permits clinicians to reproduce WHODAS 2.0 for use with their own patients free of charge. Any other use — including reproduction in an electronic data capture system — requires a licence agreement (free of charge for non-commercial use) via the WHO Classifications licensing process; translations require WHO permission. The German item wording follows the validated PCOR-MII Item Level Dictionary. Only the MII-authored FHIR content (profiles, codes, scoring) is licensed CC0; the WHODAS 2.0 item text remains © World Health Organization."
 
 * extension[capabilities].extension[displayable].valueBoolean = true
 * extension[capabilities].extension[collectable].valueBoolean = true

--- a/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
@@ -1,44 +1,59 @@
 // ============================================================================
-// WHODAS 2.0 12-Item (self-administered) - Metadata-only reference
+// WHODAS 2.0 12-Item (self-administered) - FULL questionnaire
 // ============================================================================
 // WHO Disability Assessment Schedule 2.0, 12-item version.
 //
-// LICENSING (decisive): The WHO grants clinicians the right to reproduce
-// WHODAS 2.0 for use with their own patients, but ANY electronic use -
-// including inclusion in an electronic data capture system or reproduction
-// "in any way" - requires written permission from WHO via the WHO
-// Classifications licensing process. Publishing the full item text inside a
-// FHIR Questionnaire constitutes electronic reproduction. This IG therefore
-// implements WHODAS 2.0 as a METADATA-ONLY reference (analogous to HADS /
-// EPDS): no item wording, answer text or German translations are embedded.
+// 6 ICF-aligned domains (Cognition, Mobility, Self-care, Getting along,
+// Life activities, Participation), 12 items, 30-day recall, 5-point response
+// scale (0 keine ... 4 sehr starke/nicht möglich). Simple scoring: sum of the
+// 12 item scores, range 0-48 (higher = more disability). Complex IRT-based
+// scoring is deferred to future work.
 //
-// Capabilities:
-//   - displayable  = false  (item text omitted for licensing reasons)
-//   - collectable  = false  (no answerable items embedded)
-//   - calculatable = true   (the simple-sum scoring method is public-domain
-//                            methodology and can be applied to externally
-//                            licensed/collected responses)
-//   - extractable  = true   (a resulting score Observation can be extracted)
-//   - domainAligned = true
+// German (de-DE) primary content from the validated PCOR-MII Item Level
+// Dictionary (MASTER_3EntitiesOverview.xlsx, "Item Level Dictionary" sheet).
+// PCOR-MII classifies WHODAS-12 under Domain "Generic Health" / Category
+// "Generic Health Status (GHS)" alongside PROMIS Global Health.
+// Variable IDs WHODAS12_01..12 map to linkIds whodas-whodas12-q01..q12.
 //
-// Instrument summary (documentation only, no item text reproduced):
-//   - 6 ICF-aligned domains: Cognition, Mobility, Self-care, Getting along,
-//     Life activities, Participation (2 items each = 12 items).
-//   - Recall period: last 30 days.
-//   - 5-point response scale: None(0), Mild(1), Moderate(2), Severe(3),
-//     Extreme or cannot do(4).
-//   - Simple scoring: sum of the 12 item scores, range 0-48 (higher = more
-//     disability). Complex IRT-based scoring is deferred to future work.
+// FUTURE WORK (PCOR-MII): "...we will provide a conversion table how to score
+// WHODAS 2.0 sum score on the PROMIS Generic Health Scale." => a planned
+// WHODAS-12 sum -> PROMIS Generic/Global Health conversion (ConceptMap/CQL),
+// not implemented in this version.
 //
-// Sources: WHO (Üstün TB et al.), Measuring Health and Disability: Manual for
-// WHODAS 2.0, WHO 2010, ISBN 9789241547598. German validation: Saltychev et
-// al. 2021 (PMID 34014444); Kirchberger et al. (MONICA/KORA).
+// !!! LICENSING - NOT FOR PUBLICATION UNTIL CONFIRMED !!!
+// WHODAS 2.0 © World Health Organization 2010. WHO permits clinicians to
+// reproduce WHODAS 2.0 for use with their own patients, but ANY electronic
+// use - including inclusion in an electronic data capture system or
+// reproduction "in any way" - requires WRITTEN PERMISSION from WHO via the
+// WHO Classifications licensing process. The item text is embedded here for
+// REVIEW/TESTING ONLY (per PCOR-MII direction, using their validated German
+// dictionary). This resource must NOT be published until WHO licensing (or a
+// CC0 equivalent) is confirmed.
 // ============================================================================
+
+// Shared 5-point answer scale (ordinal weights 0-4) for all 12 items.
+// {index} is the item index, allowing reuse across all question items.
+RuleSet: WhodasAnswers(index)
+* item[{index}].answerOption[0].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-0 "keine"
+* item[{index}].answerOption[0].extension.url = $hl7-ordinal-value
+* item[{index}].answerOption[0].extension.valueDecimal = 0
+* item[{index}].answerOption[1].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-1 "geringe"
+* item[{index}].answerOption[1].extension.url = $hl7-ordinal-value
+* item[{index}].answerOption[1].extension.valueDecimal = 1
+* item[{index}].answerOption[2].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[{index}].answerOption[2].extension.url = $hl7-ordinal-value
+* item[{index}].answerOption[2].extension.valueDecimal = 2
+* item[{index}].answerOption[3].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-3 "starke"
+* item[{index}].answerOption[3].extension.url = $hl7-ordinal-value
+* item[{index}].answerOption[3].extension.valueDecimal = 3
+* item[{index}].answerOption[4].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-4 "sehr starke/nicht möglich"
+* item[{index}].answerOption[4].extension.url = $hl7-ordinal-value
+* item[{index}].answerOption[4].extension.valueDecimal = 4
 
 Instance: mii-qst-pro-whodas-whodas12
 InstanceOf: mii-pr-pro-questionnaire
 Title: "MII QST PRO WHODAS 2.0 12-Item"
-Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12) - Metadata-only reference implementation. Full item content is not reproduced because electronic reproduction of WHODAS 2.0 requires written permission from WHO."
+Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). German primary content from the validated PCOR-MII Item Level Dictionary. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed."
 Usage: #definition
 * insert Version
 * insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire)
@@ -46,21 +61,149 @@ Usage: #definition
 * url = $mii-qst-pro-whodas-whodas12
 * status = #active
 * experimental = true
-* language = #en
-* title = "WHO Disability Assessment Schedule 2.0 - 12-Item (WHODAS-12)"
+* language = #de
 * code[mii] = $mii-cs-pro-questionnaire-catalogue#whodas-whodas12 "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
 
-* copyright = "WHODAS 2.0 © World Health Organization 2010. Reproduced/used only by reference. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule)."
+* copyright = "WHODAS 2.0 © World Health Organization 2010. Reproduced for review only. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule). NOT for publication until licensing is confirmed. German item content from the validated PCOR-MII Item Level Dictionary."
 
-// Capabilities - NOT displayable/collectable due to WHO licensing restrictions;
-// scoring methodology (simple sum) is public, so calculatable/extractable = true
-* extension[capabilities].extension[displayable].valueBoolean = false
-* extension[capabilities].extension[collectable].valueBoolean = false
+* extension[capabilities].extension[displayable].valueBoolean = true
+* extension[capabilities].extension[collectable].valueBoolean = true
 * extension[capabilities].extension[calculatable].valueBoolean = true
 * extension[capabilities].extension[extractable].valueBoolean = true
 * extension[capabilities].extension[domainAligned].valueBoolean = true
 
-// Metadata only - no actual questionnaire items included (licensing)
-* item[0].linkId = "WHODAS12.Notice"
+// FHIR variable for the simple-sum score calculation (all 12 items, ordinal 0-4)
+* extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
+* extension[=].valueExpression.name = "simpleSum"
+* extension[=].valueExpression.language = #text/fhirpath
+* extension[=].valueExpression.expression = "%resource.item.where(linkId.matches('^whodas-whodas12-q(0[1-9]|1[0-2])$')).answer.value.ordinal().sum()"
+
+// ============================================================================
+// Display item: instructions / shared item stem
+// ============================================================================
+
+* item[0].linkId = "WHODAS12.Description"
 * item[0].type = #display
-* item[0].text = "This questionnaire (WHODAS 2.0, 12-item) is reproduced only as a metadata reference. The item text is not included because electronic reproduction of WHODAS 2.0 requires written permission from the World Health Organization. To license WHODAS 2.0 for an electronic data capture system, see the WHO Classifications licensing process."
+* item[0].text = "Wie viele Schwierigkeiten hatten Sie in den letzten 30 Tagen:"
+
+// ============================================================================
+// Question items 1-12 (German primary; shared 5-point answer scale, weights 0-4)
+// ============================================================================
+
+// Q1 - Mobility
+* item[1].linkId = "whodas-whodas12-q01"
+* item[1].type = #choice
+* item[1].prefix = "1"
+* item[1].code = $mii-cs-pro-whodas-12#whodas12-q01
+* item[1].text = "längere Zeit (ca. 30 min) zu stehen?"
+* insert WhodasAnswers(1)
+
+// Q2 - Life activities (household)
+* item[2].linkId = "whodas-whodas12-q02"
+* item[2].type = #choice
+* item[2].prefix = "2"
+* item[2].code = $mii-cs-pro-whodas-12#whodas12-q02
+* item[2].text = "Ihren Haushaltspflichten nachzukommen?"
+* insert WhodasAnswers(2)
+
+// Q3 - Cognition (learning new tasks)
+* item[3].linkId = "whodas-whodas12-q03"
+* item[3].type = #choice
+* item[3].prefix = "3"
+* item[3].code = $mii-cs-pro-whodas-12#whodas12-q03
+* item[3].text = "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+* insert WhodasAnswers(3)
+
+// Q4 - Participation (community activities)
+* item[4].linkId = "whodas-whodas12-q04"
+* item[4].type = #choice
+* item[4].prefix = "4"
+* item[4].code = $mii-cs-pro-whodas-12#whodas12-q04
+* item[4].text = "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+* insert WhodasAnswers(4)
+
+// Q5 - Participation (emotional impact of health condition)
+* item[5].linkId = "whodas-whodas12-q05"
+* item[5].type = #choice
+* item[5].prefix = "5"
+* item[5].code = $mii-cs-pro-whodas-12#whodas12-q05
+* item[5].text = "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+* insert WhodasAnswers(5)
+
+// Q6 - Cognition (concentrating)
+* item[6].linkId = "whodas-whodas12-q06"
+* item[6].type = #choice
+* item[6].prefix = "6"
+* item[6].code = $mii-cs-pro-whodas-12#whodas12-q06
+* item[6].text = "Sich auf etwas für 10 Minuten zu konzentrieren?"
+* insert WhodasAnswers(6)
+
+// Q7 - Mobility (walking a long distance)
+* item[7].linkId = "whodas-whodas12-q07"
+* item[7].type = #choice
+* item[7].prefix = "7"
+* item[7].code = $mii-cs-pro-whodas-12#whodas12-q07
+* item[7].text = "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+* insert WhodasAnswers(7)
+
+// Q8 - Self-care (washing whole body)
+* item[8].linkId = "whodas-whodas12-q08"
+* item[8].type = #choice
+* item[8].prefix = "8"
+* item[8].code = $mii-cs-pro-whodas-12#whodas12-q08
+* item[8].text = "Ihren gesamten Körper zu waschen?"
+* insert WhodasAnswers(8)
+
+// Q9 - Self-care (getting dressed)
+* item[9].linkId = "whodas-whodas12-q09"
+* item[9].type = #choice
+* item[9].prefix = "9"
+* item[9].code = $mii-cs-pro-whodas-12#whodas12-q09
+* item[9].text = "sich anzuziehen?"
+* insert WhodasAnswers(9)
+
+// Q10 - Getting along (dealing with strangers)
+* item[10].linkId = "whodas-whodas12-q10"
+* item[10].type = #choice
+* item[10].prefix = "10"
+* item[10].code = $mii-cs-pro-whodas-12#whodas12-q10
+* item[10].text = "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+* insert WhodasAnswers(10)
+
+// Q11 - Getting along (maintaining a friendship)
+* item[11].linkId = "whodas-whodas12-q11"
+* item[11].type = #choice
+* item[11].prefix = "11"
+* item[11].code = $mii-cs-pro-whodas-12#whodas12-q11
+* item[11].text = "Eine Freundschaft aufrechtzuerhalten?"
+* insert WhodasAnswers(11)
+
+// Q12 - Life activities (work/school)
+* item[12].linkId = "whodas-whodas12-q12"
+* item[12].type = #choice
+* item[12].prefix = "12"
+* item[12].code = $mii-cs-pro-whodas-12#whodas12-q12
+* item[12].text = "Bei der Bewältigung des Arbeits-/Schulalltags?"
+* insert WhodasAnswers(12)
+
+// ============================================================================
+// Score item: WHODAS-12 simple sum (0-48)
+// ============================================================================
+
+* item[13].linkId = "whodas-whodas12-score-simple-sum"
+* item[13].type = #decimal
+* item[13].prefix = "Summenwert"
+* item[13].readOnly = true
+* item[13].text = "WHODAS 2.0 12-Item Summenwert (Simple Sum, 0-48)"
+* item[13].extension[0].url = $sdc-questionnaire-calculated-expression
+* item[13].extension[0].valueExpression.name = "whodas12SimpleSum"
+* item[13].extension[0].valueExpression.language = #text/fhirpath
+* item[13].extension[0].valueExpression.expression = "%simpleSum"
+* item[13].extension[1].url = $sdc-questionnaire-observation-extract
+* item[13].extension[1].valueBoolean = true
+* item[13].extension[2].url = $hl7-questionnaire-unit
+* item[13].extension[2].valueCoding.system = $UCUM
+* item[13].extension[2].valueCoding.code = #{score}
+* item[13].extension[3].url = $sdc-questionnaire-observation-extract-category
+* item[13].extension[3].valueCodeableConcept.coding.system = $hl7-observation-category
+* item[13].extension[3].valueCodeableConcept.coding.code = #survey

--- a/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
@@ -5,15 +5,23 @@
 //
 // 6 ICF-aligned domains (Cognition, Mobility, Self-care, Getting along,
 // Life activities, Participation), 12 items, 30-day recall, 5-point response
-// scale (0 keine ... 4 sehr starke/nicht möglich). Simple scoring: sum of the
-// 12 item scores, range 0-48 (higher = more disability). Complex IRT-based
+// scale (0 None ... 4 Extreme or cannot do). Simple scoring: sum of the 12
+// item scores, range 0-48 (higher = more disability). Complex IRT-based
 // scoring is deferred to future work.
 //
-// German (de-DE) primary content from the validated PCOR-MII Item Level
-// Dictionary (MASTER_3EntitiesOverview.xlsx, "Item Level Dictionary" sheet).
-// PCOR-MII classifies WHODAS-12 under Domain "Generic Health" / Category
-// "Generic Health Status (GHS)" alongside PROMIS Global Health.
-// Variable IDs WHODAS12_01..12 map to linkIds whodas-whodas12-q01..q12.
+// Language: English primary with German (de) translations (repo convention).
+// English item wording follows the official WHO WHODAS 2.0 12-item
+// self-administered form; German text from the validated PCOR-MII Item Level
+// Dictionary (MASTER_3EntitiesOverview.xlsx). PCOR-MII classifies WHODAS-12
+// under Domain "Generic Health" / Category "Generic Health Status (GHS)"
+// alongside PROMIS Global Health. Variable IDs WHODAS12_01..12 map to linkIds
+// whodas-whodas12-q01..q12.
+//
+// Answer modelling: items reference mii-vs-pro-whodas-12-answer-list via
+// answerValueSet. Ordinal weights (0-4) are declared as properties on the
+// mii-cs-pro-whodas-12 answer concepts. In-form .ordinal() resolution from
+// answerValueSet is engine-dependent; scoring via CQL/server is verified
+// separately.
 //
 // FUTURE WORK (PCOR-MII): "...we will provide a conversion table how to score
 // WHODAS 2.0 sum score on the PROMIS Generic Health Scale." => a planned
@@ -36,29 +44,10 @@
 // CC0 equivalent) is confirmed.
 // ============================================================================
 
-// Shared 5-point answer scale (ordinal weights 0-4) for all 12 items.
-// {index} is the item index, allowing reuse across all question items.
-RuleSet: WhodasAnswers(index)
-* item[{index}].answerOption[0].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-0 "keine"
-* item[{index}].answerOption[0].extension.url = $hl7-ordinal-value
-* item[{index}].answerOption[0].extension.valueDecimal = 0
-* item[{index}].answerOption[1].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-1 "geringe"
-* item[{index}].answerOption[1].extension.url = $hl7-ordinal-value
-* item[{index}].answerOption[1].extension.valueDecimal = 1
-* item[{index}].answerOption[2].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
-* item[{index}].answerOption[2].extension.url = $hl7-ordinal-value
-* item[{index}].answerOption[2].extension.valueDecimal = 2
-* item[{index}].answerOption[3].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-3 "starke"
-* item[{index}].answerOption[3].extension.url = $hl7-ordinal-value
-* item[{index}].answerOption[3].extension.valueDecimal = 3
-* item[{index}].answerOption[4].valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-4 "sehr starke/nicht möglich"
-* item[{index}].answerOption[4].extension.url = $hl7-ordinal-value
-* item[{index}].answerOption[4].extension.valueDecimal = 4
-
 Instance: mii-qst-pro-whodas-whodas12
 InstanceOf: mii-pr-pro-questionnaire
 Title: "MII QST PRO WHODAS 2.0 12-Item"
-Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). German primary content from the validated PCOR-MII Item Level Dictionary. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed."
+Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations. Item text embedded for review/testing only - inclusion of WHODAS 2.0 item text in an electronic system requires written permission from WHO; not for publication until licensing confirmed."
 Usage: #definition
 * insert Version
 * insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire)
@@ -66,7 +55,7 @@ Usage: #definition
 * url = $mii-qst-pro-whodas-whodas12
 * status = #active
 * experimental = true
-* language = #de
+* language = #en
 * code[mii] = $mii-cs-pro-questionnaire-catalogue#whodas-whodas12 "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
 
 * copyright = "WHODAS 2.0 © World Health Organization 2010. Reproduced for review only. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule). NOT for publication until licensing is confirmed. German item content from the validated PCOR-MII Item Level Dictionary."
@@ -89,10 +78,15 @@ Usage: #definition
 
 * item[0].linkId = "WHODAS12.Description"
 * item[0].type = #display
-* item[0].text = "Wie viele Schwierigkeiten hatten Sie in den letzten 30 Tagen:"
+* item[0].text = "In the past 30 days, how much difficulty did you have in:"
+* item[0].text.extension[0].url = $hl7-translation
+* item[0].text.extension[0].extension[0].url = "lang"
+* item[0].text.extension[0].extension[0].valueCode = #de
+* item[0].text.extension[0].extension[1].url = "content"
+* item[0].text.extension[0].extension[1].valueString = "Wie viele Schwierigkeiten hatten Sie in den letzten 30 Tagen:"
 
 // ============================================================================
-// Question items 1-12 (German primary; shared 5-point answer scale, weights 0-4)
+// Question items 1-12 (English primary + German translation; answerValueSet)
 // ============================================================================
 
 // Q1 - Mobility
@@ -100,96 +94,156 @@ Usage: #definition
 * item[1].type = #choice
 * item[1].prefix = "1"
 * item[1].code = $mii-cs-pro-whodas-12#whodas12-q01
-* item[1].text = "längere Zeit (ca. 30 min) zu stehen?"
-* insert WhodasAnswers(1)
+* item[1].text = "Standing for long periods such as 30 minutes?"
+* item[1].text.extension[0].url = $hl7-translation
+* item[1].text.extension[0].extension[0].url = "lang"
+* item[1].text.extension[0].extension[0].valueCode = #de
+* item[1].text.extension[0].extension[1].url = "content"
+* item[1].text.extension[0].extension[1].valueString = "längere Zeit (ca. 30 min) zu stehen?"
+* item[1].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q2 - Life activities (household)
 * item[2].linkId = "whodas-whodas12-q02"
 * item[2].type = #choice
 * item[2].prefix = "2"
 * item[2].code = $mii-cs-pro-whodas-12#whodas12-q02
-* item[2].text = "Ihren Haushaltspflichten nachzukommen?"
-* insert WhodasAnswers(2)
+* item[2].text = "Taking care of your household responsibilities?"
+* item[2].text.extension[0].url = $hl7-translation
+* item[2].text.extension[0].extension[0].url = "lang"
+* item[2].text.extension[0].extension[0].valueCode = #de
+* item[2].text.extension[0].extension[1].url = "content"
+* item[2].text.extension[0].extension[1].valueString = "Ihren Haushaltspflichten nachzukommen?"
+* item[2].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q3 - Cognition (learning new tasks)
 * item[3].linkId = "whodas-whodas12-q03"
 * item[3].type = #choice
 * item[3].prefix = "3"
 * item[3].code = $mii-cs-pro-whodas-12#whodas12-q03
-* item[3].text = "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
-* insert WhodasAnswers(3)
+* item[3].text = "Learning a new task, for example, learning how to get to a new place?"
+* item[3].text.extension[0].url = $hl7-translation
+* item[3].text.extension[0].extension[0].url = "lang"
+* item[3].text.extension[0].extension[0].valueCode = #de
+* item[3].text.extension[0].extension[1].url = "content"
+* item[3].text.extension[0].extension[1].valueString = "Neue Aufgaben zu lernen (z.B. erlernen an einen neuen Ort zu gelangen, den sie nicht kannten?)"
+* item[3].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q4 - Participation (community activities)
 * item[4].linkId = "whodas-whodas12-q04"
 * item[4].type = #choice
 * item[4].prefix = "4"
 * item[4].code = $mii-cs-pro-whodas-12#whodas12-q04
-* item[4].text = "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
-* insert WhodasAnswers(4)
+* item[4].text = "Joining in community activities (for example, festivities, religious or other activities) in the same way as anyone else can?"
+* item[4].text.extension[0].url = $hl7-translation
+* item[4].text.extension[0].extension[0].url = "lang"
+* item[4].text.extension[0].extension[0].valueCode = #de
+* item[4].text.extension[0].extension[1].url = "content"
+* item[4].text.extension[0].extension[1].valueString = "Wie viele Schwierigkeiten hatten Sie, an gesellschaftlichen Aktivitäten (wie z.B. Festlichkeiten, religiöse oder andere Aktivitäten) in der gleichen Art und Weise teilzunehmen, wie jeder andere?"
+* item[4].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q5 - Participation (emotional impact of health condition)
 * item[5].linkId = "whodas-whodas12-q05"
 * item[5].type = #choice
 * item[5].prefix = "5"
 * item[5].code = $mii-cs-pro-whodas-12#whodas12-q05
-* item[5].text = "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
-* insert WhodasAnswers(5)
+* item[5].text = "Being emotionally affected by your health problems?"
+* item[5].text.extension[0].url = $hl7-translation
+* item[5].text.extension[0].extension[0].url = "lang"
+* item[5].text.extension[0].extension[0].valueCode = #de
+* item[5].text.extension[0].extension[1].url = "content"
+* item[5].text.extension[0].extension[1].valueString = "Wie sehr wurden Sie durch Ihren gesundheitlichen Zustand emotional belastet?"
+* item[5].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q6 - Cognition (concentrating)
 * item[6].linkId = "whodas-whodas12-q06"
 * item[6].type = #choice
 * item[6].prefix = "6"
 * item[6].code = $mii-cs-pro-whodas-12#whodas12-q06
-* item[6].text = "Sich auf etwas für 10 Minuten zu konzentrieren?"
-* insert WhodasAnswers(6)
+* item[6].text = "Concentrating on doing something for ten minutes?"
+* item[6].text.extension[0].url = $hl7-translation
+* item[6].text.extension[0].extension[0].url = "lang"
+* item[6].text.extension[0].extension[0].valueCode = #de
+* item[6].text.extension[0].extension[1].url = "content"
+* item[6].text.extension[0].extension[1].valueString = "Sich auf etwas für 10 Minuten zu konzentrieren?"
+* item[6].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q7 - Mobility (walking a long distance)
 * item[7].linkId = "whodas-whodas12-q07"
 * item[7].type = #choice
 * item[7].prefix = "7"
 * item[7].code = $mii-cs-pro-whodas-12#whodas12-q07
-* item[7].text = "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
-* insert WhodasAnswers(7)
+* item[7].text = "Walking a long distance such as a kilometre?"
+* item[7].text.extension[0].url = $hl7-translation
+* item[7].text.extension[0].extension[0].url = "lang"
+* item[7].text.extension[0].extension[0].valueCode = #de
+* item[7].text.extension[0].extension[1].url = "content"
+* item[7].text.extension[0].extension[1].valueString = "Eine längere Strecke (ca. einen Kilometer) zu Fuß zu gehen?"
+* item[7].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q8 - Self-care (washing whole body)
 * item[8].linkId = "whodas-whodas12-q08"
 * item[8].type = #choice
 * item[8].prefix = "8"
 * item[8].code = $mii-cs-pro-whodas-12#whodas12-q08
-* item[8].text = "Ihren gesamten Körper zu waschen?"
-* insert WhodasAnswers(8)
+* item[8].text = "Washing your whole body?"
+* item[8].text.extension[0].url = $hl7-translation
+* item[8].text.extension[0].extension[0].url = "lang"
+* item[8].text.extension[0].extension[0].valueCode = #de
+* item[8].text.extension[0].extension[1].url = "content"
+* item[8].text.extension[0].extension[1].valueString = "Ihren gesamten Körper zu waschen?"
+* item[8].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q9 - Self-care (getting dressed)
 * item[9].linkId = "whodas-whodas12-q09"
 * item[9].type = #choice
 * item[9].prefix = "9"
 * item[9].code = $mii-cs-pro-whodas-12#whodas12-q09
-* item[9].text = "sich anzuziehen?"
-* insert WhodasAnswers(9)
+* item[9].text = "Getting dressed?"
+* item[9].text.extension[0].url = $hl7-translation
+* item[9].text.extension[0].extension[0].url = "lang"
+* item[9].text.extension[0].extension[0].valueCode = #de
+* item[9].text.extension[0].extension[1].url = "content"
+* item[9].text.extension[0].extension[1].valueString = "sich anzuziehen?"
+* item[9].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q10 - Getting along (dealing with strangers)
 * item[10].linkId = "whodas-whodas12-q10"
 * item[10].type = #choice
 * item[10].prefix = "10"
 * item[10].code = $mii-cs-pro-whodas-12#whodas12-q10
-* item[10].text = "Im Umgang mit anderen Personen, die Sie nicht kennen?"
-* insert WhodasAnswers(10)
+* item[10].text = "Dealing with people you do not know?"
+* item[10].text.extension[0].url = $hl7-translation
+* item[10].text.extension[0].extension[0].url = "lang"
+* item[10].text.extension[0].extension[0].valueCode = #de
+* item[10].text.extension[0].extension[1].url = "content"
+* item[10].text.extension[0].extension[1].valueString = "Im Umgang mit anderen Personen, die Sie nicht kennen?"
+* item[10].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q11 - Getting along (maintaining a friendship)
 * item[11].linkId = "whodas-whodas12-q11"
 * item[11].type = #choice
 * item[11].prefix = "11"
 * item[11].code = $mii-cs-pro-whodas-12#whodas12-q11
-* item[11].text = "Eine Freundschaft aufrechtzuerhalten?"
-* insert WhodasAnswers(11)
+* item[11].text = "Maintaining a friendship?"
+* item[11].text.extension[0].url = $hl7-translation
+* item[11].text.extension[0].extension[0].url = "lang"
+* item[11].text.extension[0].extension[0].valueCode = #de
+* item[11].text.extension[0].extension[1].url = "content"
+* item[11].text.extension[0].extension[1].valueString = "Eine Freundschaft aufrechtzuerhalten?"
+* item[11].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // Q12 - Life activities (work/school)
 * item[12].linkId = "whodas-whodas12-q12"
 * item[12].type = #choice
 * item[12].prefix = "12"
 * item[12].code = $mii-cs-pro-whodas-12#whodas12-q12
-* item[12].text = "Bei der Bewältigung des Arbeits-/Schulalltags?"
-* insert WhodasAnswers(12)
+* item[12].text = "Your day-to-day work/school?"
+* item[12].text.extension[0].url = $hl7-translation
+* item[12].text.extension[0].extension[0].url = "lang"
+* item[12].text.extension[0].extension[0].valueCode = #de
+* item[12].text.extension[0].extension[1].url = "content"
+* item[12].text.extension[0].extension[1].valueString = "Bei der Bewältigung des Arbeits-/Schulalltags?"
+* item[12].answerValueSet = Canonical(MII_VS_PRO_WHODAS_12_Answer_List)
 
 // ============================================================================
 // Score item: WHODAS-12 simple sum (0-48)
@@ -197,9 +251,14 @@ Usage: #definition
 
 * item[13].linkId = "whodas-whodas12-score-simple-sum"
 * item[13].type = #decimal
-* item[13].prefix = "Summenwert"
+* item[13].prefix = "Sum score"
 * item[13].readOnly = true
-* item[13].text = "WHODAS 2.0 12-Item Summenwert (Simple Sum, 0-48)"
+* item[13].text = "WHODAS 2.0 12-Item simple sum score (0-48)"
+* item[13].text.extension[0].url = $hl7-translation
+* item[13].text.extension[0].extension[0].url = "lang"
+* item[13].text.extension[0].extension[0].valueCode = #de
+* item[13].text.extension[0].extension[1].url = "content"
+* item[13].text.extension[0].extension[1].valueString = "WHODAS 2.0 12-Item Summenwert (Simple Sum, 0-48)"
 * item[13].extension[0].url = $sdc-questionnaire-calculated-expression
 * item[13].extension[0].valueExpression.name = "whodas12SimpleSum"
 * item[13].extension[0].valueExpression.language = #text/fhirpath

--- a/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-qst-pro-whodas-whodas12.fsh
@@ -1,0 +1,66 @@
+// ============================================================================
+// WHODAS 2.0 12-Item (self-administered) - Metadata-only reference
+// ============================================================================
+// WHO Disability Assessment Schedule 2.0, 12-item version.
+//
+// LICENSING (decisive): The WHO grants clinicians the right to reproduce
+// WHODAS 2.0 for use with their own patients, but ANY electronic use -
+// including inclusion in an electronic data capture system or reproduction
+// "in any way" - requires written permission from WHO via the WHO
+// Classifications licensing process. Publishing the full item text inside a
+// FHIR Questionnaire constitutes electronic reproduction. This IG therefore
+// implements WHODAS 2.0 as a METADATA-ONLY reference (analogous to HADS /
+// EPDS): no item wording, answer text or German translations are embedded.
+//
+// Capabilities:
+//   - displayable  = false  (item text omitted for licensing reasons)
+//   - collectable  = false  (no answerable items embedded)
+//   - calculatable = true   (the simple-sum scoring method is public-domain
+//                            methodology and can be applied to externally
+//                            licensed/collected responses)
+//   - extractable  = true   (a resulting score Observation can be extracted)
+//   - domainAligned = true
+//
+// Instrument summary (documentation only, no item text reproduced):
+//   - 6 ICF-aligned domains: Cognition, Mobility, Self-care, Getting along,
+//     Life activities, Participation (2 items each = 12 items).
+//   - Recall period: last 30 days.
+//   - 5-point response scale: None(0), Mild(1), Moderate(2), Severe(3),
+//     Extreme or cannot do(4).
+//   - Simple scoring: sum of the 12 item scores, range 0-48 (higher = more
+//     disability). Complex IRT-based scoring is deferred to future work.
+//
+// Sources: WHO (Üstün TB et al.), Measuring Health and Disability: Manual for
+// WHODAS 2.0, WHO 2010, ISBN 9789241547598. German validation: Saltychev et
+// al. 2021 (PMID 34014444); Kirchberger et al. (MONICA/KORA).
+// ============================================================================
+
+Instance: mii-qst-pro-whodas-whodas12
+InstanceOf: mii-pr-pro-questionnaire
+Title: "MII QST PRO WHODAS 2.0 12-Item"
+Description: "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12) - Metadata-only reference implementation. Full item content is not reproduced because electronic reproduction of WHODAS 2.0 requires written permission from WHO."
+Usage: #definition
+* insert Version
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire)
+
+* url = $mii-qst-pro-whodas-whodas12
+* status = #active
+* experimental = true
+* language = #en
+* title = "WHO Disability Assessment Schedule 2.0 - 12-Item (WHODAS-12)"
+* code[mii] = $mii-cs-pro-questionnaire-catalogue#whodas-whodas12 "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
+
+* copyright = "WHODAS 2.0 © World Health Organization 2010. Reproduced/used only by reference. Electronic reproduction of the instrument requires written permission from WHO (https://www.who.int/standards/classifications/international-classification-of-functioning-disability-and-health/who-disability-assessment-schedule)."
+
+// Capabilities - NOT displayable/collectable due to WHO licensing restrictions;
+// scoring methodology (simple sum) is public, so calculatable/extractable = true
+* extension[capabilities].extension[displayable].valueBoolean = false
+* extension[capabilities].extension[collectable].valueBoolean = false
+* extension[capabilities].extension[calculatable].valueBoolean = true
+* extension[capabilities].extension[extractable].valueBoolean = true
+* extension[capabilities].extension[domainAligned].valueBoolean = true
+
+// Metadata only - no actual questionnaire items included (licensing)
+* item[0].linkId = "WHODAS12.Notice"
+* item[0].type = #display
+* item[0].text = "This questionnaire (WHODAS 2.0, 12-item) is reproduced only as a metadata reference. The item text is not included because electronic reproduction of WHODAS 2.0 requires written permission from the World Health Organization. To license WHODAS 2.0 for an electronic data capture system, see the WHO Classifications licensing process."

--- a/input/fsh/definitions/whodas/mii-vs-pro-whodas-12.fsh
+++ b/input/fsh/definitions/whodas/mii-vs-pro-whodas-12.fsh
@@ -1,0 +1,14 @@
+// WHODAS-12 answer list ValueSet: 5-point ordinal scale (0-4)
+ValueSet: MII_VS_PRO_WHODAS_12_Answer_List
+Id: mii-vs-pro-whodas-12-answer-list
+Title: "MII VS PRO WHODAS 2.0 12-Item Answer List"
+Description: "5-point response scale for all WHODAS-12 items (0 = keine, 1 = geringe, 2 = mäßige, 3 = starke, 4 = sehr starke/nicht möglich)"
+* ^url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
+* insert PR_CS_VS_Version
+* ^status = #active
+* ^experimental = true
+* https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12#whodas12-answer-0
+* https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12#whodas12-answer-1
+* https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12#whodas12-answer-2
+* https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12#whodas12-answer-3
+* https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12#whodas12-answer-4

--- a/input/fsh/definitions/whodas/mii-vs-pro-whodas-12.fsh
+++ b/input/fsh/definitions/whodas/mii-vs-pro-whodas-12.fsh
@@ -2,7 +2,7 @@
 ValueSet: MII_VS_PRO_WHODAS_12_Answer_List
 Id: mii-vs-pro-whodas-12-answer-list
 Title: "MII VS PRO WHODAS 2.0 12-Item Answer List"
-Description: "5-point response scale for all WHODAS-12 items (0 = keine, 1 = geringe, 2 = mäßige, 3 = starke, 4 = sehr starke/nicht möglich)"
+Description: "5-point response scale for all WHODAS-12 items (0 = None, 1 = Mild, 2 = Moderate, 3 = Severe, 4 = Extreme or cannot do). MII-controlled for reliable ordinal() score calculation; German labels via designations on mii-cs-pro-whodas-12."
 * ^url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list"
 * insert PR_CS_VS_Version
 * ^status = #active

--- a/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
+++ b/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
@@ -1,7 +1,7 @@
 // ============================================================================
 // WHODAS 2.0 12-Item QuestionnaireResponse Example
 // ============================================================================
-// Verification scenario: every one of the 12 items answered "mäßige" (ordinal 2).
+// Verification scenario: every one of the 12 items answered "Moderate" (ordinal 2).
 //   Simple sum = 12 items × 2 = 24 (range 0-48).
 // The score item (whodas-whodas12-score-simple-sum) therefore carries 24, and
 // the score Observation below mirrors that value.
@@ -10,7 +10,7 @@
 Instance: mii-exa-pro-whodas12-response-01
 InstanceOf: mii-pr-pro-questionnaire-response
 Title: "MII EXA PRO WHODAS 2.0 12-Item Response"
-Description: "Complete WHODAS-12 QuestionnaireResponse example. All 12 items answered 'mäßige' (ordinal 2); simple sum = 24."
+Description: "Complete WHODAS-12 QuestionnaireResponse example. All 12 items answered 'Moderate' (ordinal 2); simple sum = 24."
 Usage: #example
 * insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response)
 * questionnaire = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12"
@@ -20,51 +20,51 @@ Usage: #example
 
 // Q1 (value: 2)
 * item[+].linkId = "whodas-whodas12-q01"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q2 (value: 2)
 * item[+].linkId = "whodas-whodas12-q02"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q3 (value: 2)
 * item[+].linkId = "whodas-whodas12-q03"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q4 (value: 2)
 * item[+].linkId = "whodas-whodas12-q04"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q5 (value: 2)
 * item[+].linkId = "whodas-whodas12-q05"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q6 (value: 2)
 * item[+].linkId = "whodas-whodas12-q06"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q7 (value: 2)
 * item[+].linkId = "whodas-whodas12-q07"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q8 (value: 2)
 * item[+].linkId = "whodas-whodas12-q08"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q9 (value: 2)
 * item[+].linkId = "whodas-whodas12-q09"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q10 (value: 2)
 * item[+].linkId = "whodas-whodas12-q10"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q11 (value: 2)
 * item[+].linkId = "whodas-whodas12-q11"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // Q12 (value: 2)
 * item[+].linkId = "whodas-whodas12-q12"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
 
 // ===== Simple Sum Score: 12 × 2 = 24 =====
 * item[+].linkId = "whodas-whodas12-score-simple-sum"
@@ -78,7 +78,7 @@ Usage: #example
 Instance: mii-exa-pro-whodas12-score-simple-sum
 InstanceOf: mii-pr-pro-score-instance
 Title: "WHODAS 2.0 12-Item Simple Sum Score Observation"
-Description: "WHODAS-12 simple sum score observation (all items 'mäßige': 12 × 2 = 24)."
+Description: "WHODAS-12 simple sum score observation (all items 'Moderate': 12 × 2 = 24)."
 Usage: #example
 * insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance)
 * status = #final

--- a/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
+++ b/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
@@ -1,0 +1,96 @@
+// ============================================================================
+// WHODAS 2.0 12-Item QuestionnaireResponse Example
+// ============================================================================
+// Verification scenario: every one of the 12 items answered "mäßige" (ordinal 2).
+//   Simple sum = 12 items × 2 = 24 (range 0-48).
+// The score item (whodas-whodas12-score-simple-sum) therefore carries 24, and
+// the score Observation below mirrors that value.
+// ============================================================================
+
+Instance: mii-exa-pro-whodas12-response-01
+InstanceOf: mii-pr-pro-questionnaire-response
+Title: "MII EXA PRO WHODAS 2.0 12-Item Response"
+Description: "Complete WHODAS-12 QuestionnaireResponse example. All 12 items answered 'mäßige' (ordinal 2); simple sum = 24."
+Usage: #example
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response)
+* questionnaire = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12"
+* status = #completed
+* subject.reference = "Patient/mii-exa-pro-patient"
+* authored = "2026-02-01"
+
+// Q1 (value: 2)
+* item[+].linkId = "whodas-whodas12-q01"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q2 (value: 2)
+* item[+].linkId = "whodas-whodas12-q02"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q3 (value: 2)
+* item[+].linkId = "whodas-whodas12-q03"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q4 (value: 2)
+* item[+].linkId = "whodas-whodas12-q04"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q5 (value: 2)
+* item[+].linkId = "whodas-whodas12-q05"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q6 (value: 2)
+* item[+].linkId = "whodas-whodas12-q06"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q7 (value: 2)
+* item[+].linkId = "whodas-whodas12-q07"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q8 (value: 2)
+* item[+].linkId = "whodas-whodas12-q08"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q9 (value: 2)
+* item[+].linkId = "whodas-whodas12-q09"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q10 (value: 2)
+* item[+].linkId = "whodas-whodas12-q10"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q11 (value: 2)
+* item[+].linkId = "whodas-whodas12-q11"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// Q12 (value: 2)
+* item[+].linkId = "whodas-whodas12-q12"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
+
+// ===== Simple Sum Score: 12 × 2 = 24 =====
+* item[+].linkId = "whodas-whodas12-score-simple-sum"
+* item[=].answer.valueDecimal = 24
+
+
+// ============================================================================
+// WHODAS-12 Score Observation Example (mirrors the calculated simple sum)
+// ============================================================================
+
+Instance: mii-exa-pro-whodas12-score-simple-sum
+InstanceOf: mii-pr-pro-score-instance
+Title: "WHODAS 2.0 12-Item Simple Sum Score Observation"
+Description: "WHODAS-12 simple sum score observation (all items 'mäßige': 12 × 2 = 24)."
+Usage: #example
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance)
+* status = #final
+* category.coding = $hl7-observation-category#survey "Survey"
+* code.coding[+] = $SCT#715823002 "WHODAS (World Health Organization Disability Assessment Schedule) 2.0 score"
+* code.coding[+].system = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-score-catalogue"
+* code.coding[=].code = #whodas12-simple-sum
+* code.coding[=].display = "WHODAS 2.0 12-Item Simple Sum Score (0-48)"
+* subject.reference = "Patient/mii-exa-pro-patient"
+* effectiveDateTime = "2026-02-01"
+* valueQuantity.value = 24
+* valueQuantity.unit = "{score}"
+* valueQuantity.system = $UCUM
+* valueQuantity.code = #{score}
+* derivedFrom.reference = "QuestionnaireResponse/mii-exa-pro-whodas12-response-01"

--- a/input/fsh/profiles/mii-cs-pro-questionnaire-catalogue.fsh
+++ b/input/fsh/profiles/mii-cs-pro-questionnaire-catalogue.fsh
@@ -27,6 +27,7 @@ Description: "MII CS PRO Questionnaire Catalogue for PRO Questionnaires used in 
 * #proctcae-breast-de "PRO-CTCAE German Breast Cancer Subset (21 Symptoms)"
 * #proctcae-onkologisches-basisscreening "PRO-CTCAE Onkologisches Basisscreening (DKG, MIDOS2-äquivalente Symptome)"
 * #midos-midos2 "MIDOS2 (Minimales Dokumentationssystem für Palliativpatienten, DGP)"
+* #whodas-whodas12 "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
 
 // TODO: Investigate whether the four latest questionnaires (HADS, EPDS, CES-D, K6) are
 // separate entities or part of some bigger PRO framework for proper categorization

--- a/input/fsh/profiles/mii-cs-pro-score-catalogue.fsh
+++ b/input/fsh/profiles/mii-cs-pro-score-catalogue.fsh
@@ -72,6 +72,9 @@ Description: "MII CS PRO Score Catalogue for PRO Scores used in the MII PROMs Mo
 * #dass21-anxiety-equiv "DASS-21 Anxiety DASS-42 Equivalent Score"
 * #dass21-stress-equiv "DASS-21 Stress DASS-42 Equivalent Score"
 
+// WHODAS 2.0 12-Item Scores (higher = worse disability)
+* #whodas12-simple-sum "WHODAS 2.0 12-Item Simple Sum Score (0-48)"
+
 // PRO-CTCAE Scores (higher = worse AE burden)
 * #proctcae-composite-grade "PRO-CTCAE Composite Grade (per Adverse Event)"
 * #proctcae-acs "PRO-CTCAE Average Composite Score (ACS)"

--- a/input/pagecontent/whodas.md
+++ b/input/pagecontent/whodas.md
@@ -1,0 +1,43 @@
+### Klinischer Kontext
+
+Der **WHODAS 2.0** (WHO Disability Assessment Schedule 2.0) ist das generische Instrument der WHO zur Erfassung von **Funktionsfähigkeit und Beeinträchtigung** über alle Erkrankungen hinweg, methodisch an der ICF (International Classification of Functioning, Disability and Health) ausgerichtet. Diese Implementierung nutzt die **12-Item-Kurzform (Selbstauskunft)**.
+
+Die 12 Items decken **sechs ICF-Domänen** ab: Kognition, Mobilität, Selbstversorgung, Umgang mit anderen Menschen, Lebensaktivitäten und Partizipation. Erfasst wird die Beeinträchtigung der **letzten 30 Tage** auf einer fünfstufigen Skala (0 = keine, 1 = leichte, 2 = mäßige, 3 = schwere, 4 = extreme Beeinträchtigung / nicht möglich).
+
+**Scoring und Interpretation** (Summenwert 0–48):
+- Einfaches Scoring (WHO „simple scoring"): Summe der 12 Item-Werte (je 0–4), Wertebereich **0–48**.
+- **Höhere Werte = stärkere Beeinträchtigung** (Einschränkungsscore).
+- Die komplexe, IRT-basierte WHO-Bewertung (0–100) ist in dieser Version noch nicht abgebildet (Folgearbeit).
+
+**Einordnung im MII-PRO-Modul:** PCOR-MII führt WHODAS-12 unter der Domäne „Generic Health" / Kategorie „Generic Health Status" gemeinsam mit PROMIS Global Health. Eine geplante Konversion des WHODAS-Summenscores auf die PROMIS Generic/Global Health Scale (ConceptMap/CQL) ist als Folgearbeit vorgesehen.
+
+### FHIR-Implementierung
+
+> **Sprachstrategie:** Englisch als Primärsprache (Original-Instrument), deutsche Texte als Translations/Designations. Der deutsche Item-Wortlaut folgt dem validierten PCOR-MII Item Level Dictionary.
+
+**Canonical URL:** `https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12`
+
+**Besonderheiten:**
+- linkIds `whodas-whodas12-q01` … `whodas-whodas12-q12`.
+- Antwortskala über `answerValueSet` (`mii-vs-pro-whodas-12-answer-list`); ordinale Gewichte (0–4) als Property auf den CodeSystem-Konzepten (`mii-cs-pro-whodas-12`).
+- Automatische Score-Berechnung via FHIRPath (`.ordinal().sum()`). Hinweis: `.ordinal()`-Auflösung aus `answerValueSet` ist engine-abhängig; robustes Scoring via CQL/Server.
+
+**Score-Repräsentation:**
+- **ObservationDefinition:** `mii-obsdef-pro-score-whodas12-simple-sum` — Wertebereich 0–48, SNOMED `715823002`, MII-Score-Catalogue `whodas12-simple-sum`, Richtung: höher = größere Beeinträchtigung.
+
+### Lizenz
+
+> **Wichtig:** WHODAS 2.0 ist **© World Health Organization 2010** (*Measuring Health and Disability: Manual for WHODAS 2.0*, ISBN 9789241547598).
+
+- WHO gestattet **Klinikerinnen und Klinikern die Reproduktion von WHODAS 2.0 zur Nutzung bei eigenen Patient:innen — kostenfrei und ohne gesonderte Genehmigung**.
+- **Jede andere Nutzung — insbesondere die Einbindung in elektronische Datenerfassungssysteme** (wie diesen IG) — **erfordert eine WHO-Lizenzvereinbarung** über den WHO-Classifications-Lizenzprozess. Diese ist für **nicht-kommerzielle Nutzer kostenlos** und verlangt die Online-Zustimmung zu einer Nutzungsvereinbarung.
+- **Übersetzungen** erfordern zusätzlich die Genehmigung der WHO.
+- Nur die **MII-eigenen FHIR-Inhalte** (Profile, Codes, Scoring-Logik) stehen unter **CC0**; der **WHODAS-2.0-Itemtext bleibt © WHO**.
+
+Diese Bedingungen sind maschinenlesbar im `copyright`-Element der Questionnaire- und CodeSystem-Ressourcen hinterlegt.
+
+### Quellen
+
+- World Health Organization. *Measuring Health and Disability: Manual for WHO Disability Assessment Schedule (WHODAS 2.0)*. Genf: WHO; 2010. ISBN 9789241547598.
+- Kirchberger I, et al. Validation of the WHODAS 2.0 in a population-based sample (MONICA/KORA). *Population Health Metrics* 2014;12:27. doi:10.1186/s12963-014-0027-8
+- Saltychev M, et al. Psychometric properties of the WHODAS 2.0 — systematic review. PMID 31335215.

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -146,6 +146,8 @@ pages:
       title: MIDOS2 (Palliativmedizin)
     proms-onkologisches-basisscreening.md:
       title: Onkologisches Basisscreening (PRO-CTCAE)
+    whodas.md:
+      title: WHODAS 2.0 (12-Item)
     minimal-reference-questionnaires.md:
       title: Minimal Reference Questionnaires
   domain-based-scoring.md:
@@ -189,6 +191,7 @@ menu:
     PROMIS-16: promis-16.html
     BDI-II: bdi-ii.html
     DASS-21: dass-21.html
+    WHODAS 2.0: whodas.html
   Domain-Based Scoring:
     Domain-Based Scoring: domain-based-scoring.html
     Domains: domains.html


### PR DESCRIPTION
## Was
Integriert das **WHODAS 2.0 12-Item (Selbstauskunft)** als vollständiges Instrument — mit **maschinenlesbaren, korrekten WHO-Lizenzbedingungen** statt des bisherigen „NOT FOR PUBLICATION"-Markers.

### Instrument
- Questionnaire (12 Items, 6 ICF-Domänen, 30-Tage-Recall, 5-stufige Skala 0–4), EN-primär + DE-Translations (validierte PCOR-MII-Wortlaute).
- Antworten via `answerValueSet` + ordinalValue-Gewichte (0–4) auf CodeSystem-Konzepten.
- **Einschränkungsscore** ObsDef `mii-obsdef-pro-score-whodas12-simple-sum` (0–48, SNOMED 715823002, MII-Katalog `whodas12-simple-sum`, höher = mehr Beeinträchtigung).
- Beispiel-QR + Score-Observation.
- IG-Seite `whodas.md` + pages/Menü-Registrierung.

### Lizenz (korrekt angegeben)
`copyright`-Element auf Questionnaire + CodeSystem:
- WHODAS 2.0 **© WHO 2010**.
- Kliniker dürfen es **kostenfrei bei eigenen Patient:innen** nutzen.
- **Jede andere Nutzung — inkl. elektronischer Datenerfassung (dieser IG) — erfordert eine WHO-Lizenzvereinbarung** (für nicht-kommerziell kostenlos) über den WHO-Classifications-Prozess.
- **Übersetzungen** erfordern WHO-Genehmigung.
- MII-FHIR-Inhalte **CC0**; WHODAS-Itemtext bleibt **© WHO**.

> ⚠️ **Governance-Hinweis:** Das Angeben der Bedingungen ersetzt nicht formal die WHO-Nutzungsvereinbarung. Merge/Publikation erfolgt auf Maintainer-Entscheidung; die WHO-Lizenz sollte parallel abgeschlossen werden.

## Validierung
- `sushi .` → 0 Errors / 0 Warnings.
- answerValueSet via `expand-valuesets.js` expandiert (VS trägt `expansion`) → QR-Antwortvalidierung sauber. Dauerhaft im CI via #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)