### PR TITLE
release: v2026.5.0

### DIFF
--- a/fsh-generated/resources/Bundle-mii-exa-pro-bdi-ii-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-bdi-ii-bundle.json
@@ -59,7 +59,7 @@
             "display": "3 points (variant b)"
           }
         ],
-        "version": "2026.4.1",
+        "version": "2026.5.0",
         "experimental": true,
         "valueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-bdi-bdi2",
         "count": 10
@@ -79,7 +79,7 @@
         "title": "MII VS PRO BDI-II",
         "description": "MII VS PRO BDI-II ValueSet for Beck Depression Inventory II (BDI-II) Questionnaire",
         "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-bdi-bdi2-short",
-        "version": "2026.4.1",
+        "version": "2026.5.0",
         "experimental": true,
         "compose": {
           "include": [
@@ -118,7 +118,7 @@
         "title": "MII VS PRO BDI-II",
         "description": "MII VS PRO BDI-II ValueSet for Beck Depression Inventory II (BDI-II) Questionnaire",
         "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-bdi-bdi2-long",
-        "version": "2026.4.1",
+        "version": "2026.5.0",
         "experimental": true,
         "compose": {
           "include": [
@@ -163,7 +163,7 @@
         "id": "mii-qst-pro-bdi-bdi2",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
           ]
         },
         "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-bdi-bdi2",
@@ -406,7 +406,7 @@
             "readOnly": true
           }
         ],
-        "version": "2026.4.1",
+        "version": "2026.5.0",
         "status": "active",
         "experimental": true,
         "language": "de"
@@ -423,7 +423,7 @@
         "id": "mii-exa-pro-bdi-bdi2",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
           ]
         },
         "subject": {
@@ -686,7 +686,7 @@
         "id": "mii-exa-pro-bdi-ii-observation",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "valueQuantity": {

--- a/fsh-generated/resources/Bundle-mii-exa-pro-eortc-qlq-c30-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-eortc-qlq-c30-bundle.json
@@ -13,7 +13,7 @@
         "id": "mii-qst-pro-eortc-qlq-c30",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
           ]
         },
         "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-eortc-qlq-c30",
@@ -64,7 +64,7 @@
             "id": "eortc-qlq-c30-cs",
             "meta": {
               "profile": [
-                "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+                "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
               ]
             },
             "concept": [
@@ -245,7 +245,7 @@
                 "display": "7 - Perfect"
               }
             ],
-            "version": "2026.4.1",
+            "version": "2026.5.0",
             "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-eortc-qlq-c30",
             "status": "active",
             "content": "complete",
@@ -256,7 +256,7 @@
             "id": "eortc-qlq-c30-4pt",
             "meta": {
               "profile": [
-                "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+                "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
               ]
             },
             "compose": {
@@ -284,7 +284,7 @@
                 }
               ]
             },
-            "version": "2026.4.1",
+            "version": "2026.5.0",
             "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-4pt",
             "status": "active"
           },
@@ -293,7 +293,7 @@
             "id": "eortc-qlq-c30-7pt",
             "meta": {
               "profile": [
-                "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+                "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
               ]
             },
             "compose": {
@@ -326,7 +326,7 @@
                 }
               ]
             },
-            "version": "2026.4.1",
+            "version": "2026.5.0",
             "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-7pt",
             "status": "active"
           }
@@ -850,7 +850,7 @@
             "text": "Calculated Scores (0-100 scale)"
           }
         ],
-        "version": "2026.4.1",
+        "version": "2026.5.0",
         "status": "active",
         "experimental": true,
         "language": "en",
@@ -869,7 +869,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-response",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
           ]
         },
         "subject": {
@@ -1253,7 +1253,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-pf",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1313,7 +1313,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-rf",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1365,7 +1365,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-ef",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1417,7 +1417,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-cf",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1469,7 +1469,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-sf",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1521,7 +1521,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-fa",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1573,7 +1573,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-nv",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1625,7 +1625,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-pa",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1677,7 +1677,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-dy",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1729,7 +1729,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-sl",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1781,7 +1781,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-ap",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1833,7 +1833,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-co",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1885,7 +1885,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-di",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1937,7 +1937,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-fi",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [
@@ -1989,7 +1989,7 @@
         "id": "mii-exa-pro-eortc-qlq-c30-observation-ql",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "category": [

--- a/fsh-generated/resources/Bundle-mii-exa-pro-phq-9-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-phq-9-bundle.json
@@ -13,7 +13,7 @@
         "id": "mii-qst-pro-phq-9",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
           ]
         },
         "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-9",
@@ -1804,7 +1804,7 @@
             }
           }
         ],
-        "version": "2026.4.1",
+        "version": "2026.5.0",
         "status": "active",
         "experimental": true,
         "language": "en",
@@ -1822,7 +1822,7 @@
         "id": "mii-exa-pro-phq-9-response",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
           ]
         },
         "item": [
@@ -1975,7 +1975,7 @@
         "id": "mii-exa-pro-phq-9-observation",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
           ]
         },
         "valueQuantity": {

--- a/fsh-generated/resources/Bundle-mii-exa-pro-promis-29-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-promis-29-bundle.json
@@ -9,7 +9,7 @@
         "id": "patient-example-1",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/core/modul-person/StructureDefinition/Patient|2026.5.0"
           ]
         },
         "identifier": [
@@ -37,7 +37,7 @@
         "id": "promis-29-response-1",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
           ]
         },
         "item": [
@@ -579,7 +579,7 @@
         "id": "obs-promis-29-physical-function-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-physical-function-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-physical-function-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -625,7 +625,7 @@
         "id": "obs-promis-29-anxiety-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-anxiety-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-anxiety-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -671,7 +671,7 @@
         "id": "obs-promis-29-depression-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-depression-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-depression-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -717,7 +717,7 @@
         "id": "obs-promis-29-fatigue-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-fatigue-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-fatigue-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -763,7 +763,7 @@
         "id": "obs-promis-29-sleep-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-sleep-disturbance-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-sleep-disturbance-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -809,7 +809,7 @@
         "id": "obs-promis-29-social-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-social-function-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-social-function-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -855,7 +855,7 @@
         "id": "obs-promis-29-pain-interference-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-pain-interference-tscore|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-pain-interference-tscore|2026.5.0"
           ]
         },
         "valueQuantity": {
@@ -901,7 +901,7 @@
         "id": "obs-promis-29-pain-intensity",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-pain-intensity|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-pain-intensity|2026.5.0"
           ]
         },
         "valueQuantity": {

--- a/fsh-generated/resources/Bundle-mii-exa-pro-promis-depression-sf4a-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-promis-depression-sf4a-bundle.json
@@ -32,7 +32,7 @@
         "id": "mii-exa-pro-promis-depression-sf4a-response",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
           ]
         },
         "item": [
@@ -116,7 +116,7 @@
         "id": "mii-exa-pro-promis-depression-sf4a-raw-score",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-depression-sf4a-raw-score|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-depression-sf4a-raw-score|2026.5.0"
           ]
         },
         "category": [
@@ -164,7 +164,7 @@
         "id": "mii-exa-pro-promis-depression-sf4a-tscore",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-depression-t-score|2026.4.1"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-depression-t-score|2026.5.0"
           ]
         },
         "category": [

--- a/fsh-generated/resources/CapabilityStatement-mii-cps-pro-capabilitystatement.json
+++ b/fsh-generated/resources/CapabilityStatement-mii-cps-pro-capabilitystatement.json
@@ -1285,7 +1285,7 @@
       "mode": "server"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_CPS_PRO_CapabilityStatement",
   "title": "MII CPS PRO CapabilityStatement",
   "status": "active",

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-bdi-bdi2.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-bdi-bdi2.json
@@ -49,7 +49,7 @@
       "display": "3 points (variant b)"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "valueSet": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-bdi-bdi2",
   "count": 10

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-dass-21.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-dass-21.json
@@ -259,7 +259,7 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "caseSensitive": true,
   "count": 25

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-eortc-qlq-c30.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-eortc-qlq-c30.json
@@ -159,7 +159,7 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "caseSensitive": true,
   "count": 15

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-eq-5d-value-set.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-eq-5d-value-set.json
@@ -720,7 +720,7 @@
     }
   ],
   "language": "de-DE",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "hierarchyMeaning": "grouped-by",
   "property": [

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-midos2.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-midos2.json
@@ -273,7 +273,7 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "caseSensitive": true,
   "copyright": "MIDOS2 ist ein Instrument der Deutschen Gesellschaft für Palliativmedizin (DGP), frei verwendbar für klinische und Forschungszwecke.",

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-phq-15-answers.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-phq-15-answers.json
@@ -57,7 +57,7 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "language": "en",
   "property": [
     {

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-pro-ctcae.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-pro-ctcae.json
@@ -2965,7 +2965,7 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "caseSensitive": true,
   "copyright": "PRO-CTCAE is a product of the US National Cancer Institute (NCI). The PRO-CTCAE items, calculation algorithms, and item library are available free of charge for use in cancer clinical trials.",

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-questionnaire-catalogue.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-questionnaire-catalogue.json
@@ -85,6 +85,6 @@
       "display": "WHODAS 2.0 12-Item (WHO Disability Assessment Schedule 2.0, self-administered)"
     }
   ],
-  "version": "2026.4.1",
-  "count": 18
+  "version": "2026.5.0",
+  "count": 19
 }

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-score-catalogue.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-score-catalogue.json
@@ -173,6 +173,6 @@
       "display": "PRO-CTCAE Average Composite Score (ACS)"
     }
   ],
-  "version": "2026.4.1",
-  "count": 40
+  "version": "2026.5.0",
+  "count": 41
 }

--- a/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
+++ b/fsh-generated/resources/CodeSystem-mii-cs-pro-whodas-12.json
@@ -209,7 +209,7 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "caseSensitive": true,
   "language": "en",

--- a/fsh-generated/resources/ConceptMap-mii-cm-pro-bdi-ii-to-promis-depression-observation.json
+++ b/fsh-generated/resources/ConceptMap-mii-cm-pro-bdi-ii-to-promis-depression-observation.json
@@ -28,6 +28,6 @@
       ]
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active"
 }

--- a/fsh-generated/resources/ImplementationGuide-mii-ig-pro.json
+++ b/fsh-generated/resources/ImplementationGuide-mii-ig-pro.json
@@ -3,7 +3,7 @@
   "id": "mii-ig-pro",
   "language": "de-DE",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ImplementationGuide/mii-ig-pro",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_IG_PRO",
   "title": "MII IG PRO",
   "status": "active",
@@ -516,6 +516,14 @@
       },
       {
         "reference": {
+          "reference": "CodeSystem/mii-cs-pro-whodas-12"
+        },
+        "name": "MII CS PRO WHODAS 2.0 12-Item Response Scale and Item Codes",
+        "description": "CodeSystem for the WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12), with item codes and a 5-point answer scale. English primary displays with German designations. The answer concepts carry ordinalValue properties (0-4) enabling SDC ordinal scoring via answerValueSet. WHODAS 2.0 © WHO 2010; electronic use requires a WHO licence (see copyright).",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "StructureDefinition/mii-ex-pro-score-score-health-correlation"
         },
         "name": "MII Ex PRO Score Score Health Correlation",
@@ -624,6 +632,14 @@
         },
         "name": "MII EXA PRO PROMIS-29 Response (German)",
         "description": "Example QuestionnaireResponse for PROMIS-29 Profile v2.1 (German variant) - demonstrates response compatibility between language variants",
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response"
+      },
+      {
+        "reference": {
+          "reference": "QuestionnaireResponse/mii-exa-pro-whodas12-response-01"
+        },
+        "name": "MII EXA PRO WHODAS 2.0 12-Item Response",
+        "description": "Complete WHODAS-12 QuestionnaireResponse example. All 12 items answered 'Moderate' (ordinal 2); simple sum = 24.",
         "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response"
       },
       {
@@ -1124,6 +1140,14 @@
       },
       {
         "reference": {
+          "reference": "Questionnaire/mii-qst-pro-whodas-whodas12"
+        },
+        "name": "MII QST PRO WHODAS 2.0 12-Item",
+        "description": "WHO Disability Assessment Schedule 2.0, 12-item self-administered version (WHODAS-12). English primary with German translations (validated PCOR-MII wording). WHODAS 2.0 © WHO 2010 — see copyright for licensing conditions (a WHO licence is required for electronic/data-capture use).",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "ValueSet/mii-vs-pro-bdi-bdi2-short"
         },
         "name": "MII VS PRO BDI-II",
@@ -1308,6 +1332,14 @@
       },
       {
         "reference": {
+          "reference": "ValueSet/mii-vs-pro-whodas-12-answer-list"
+        },
+        "name": "MII VS PRO WHODAS 2.0 12-Item Answer List",
+        "description": "5-point response scale for all WHODAS-12 items (0 = None, 1 = Mild, 2 = Moderate, 3 = Severe, 4 = Extreme or cannot do). MII-controlled for reliable ordinal() score calculation; German labels via designations on mii-cs-pro-whodas-12.",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "SearchParameter/mii-sp-pro-observationdefinition-code"
         },
         "name": "mii-sp-pro-observationdefinition-code",
@@ -1428,6 +1460,22 @@
         },
         "name": "PROMIS Depression T-Score, derived from BDI-II Observation Example",
         "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance"
+      },
+      {
+        "reference": {
+          "reference": "ObservationDefinition/mii-obsdef-pro-score-whodas12-simple-sum"
+        },
+        "name": "WHODAS 2.0 12-Item Simple Sum Score",
+        "description": "Sum of the 12 WHODAS 2.0 item scores (each 0-4), range 0-48. Higher scores indicate greater disability. WHO simple scoring method; complex IRT-based scoring deferred to future work.",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "Observation/mii-exa-pro-whodas12-score-simple-sum"
+        },
+        "name": "WHODAS 2.0 12-Item Simple Sum Score Observation",
+        "description": "WHODAS-12 simple sum score observation (all items 'Moderate': 12 × 2 = 24).",
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance"
       }
     ],
     "page": {
@@ -1515,6 +1563,11 @@
               "generation": "markdown"
             },
             {
+              "nameUrl": "phq-15.html",
+              "title": "PHQ-15",
+              "generation": "markdown"
+            },
+            {
               "nameUrl": "eq-5d-5l.html",
               "title": "EQ-5D-5L",
               "generation": "markdown",
@@ -1578,6 +1631,11 @@
             {
               "nameUrl": "proms-onkologisches-basisscreening.html",
               "title": "Onkologisches Basisscreening (PRO-CTCAE)",
+              "generation": "markdown"
+            },
+            {
+              "nameUrl": "whodas.html",
+              "title": "WHODAS 2.0 (12-Item)",
               "generation": "markdown"
             },
             {

--- a/fsh-generated/resources/Observation-mii-exa-pro-bdi-ii-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-bdi-ii-observation.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-bdi-ii-observation",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "valueQuantity": {

--- a/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-anxiety-equiv.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-anxiety-equiv.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-score-anxiety-equiv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-anxiety-raw.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-anxiety-raw.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-score-anxiety-raw",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-depression-equiv.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-depression-equiv.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-score-depression-equiv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-depression-raw.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-depression-raw.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-score-depression-raw",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-stress-equiv.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-stress-equiv.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-score-stress-equiv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-stress-raw.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-dass-dass21-score-stress-raw.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-score-stress-raw",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-ap.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-ap.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-ap",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-cf.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-cf.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-cf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-co.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-co.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-co",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-di.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-di.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-di",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-dy.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-dy.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-dy",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-ef.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-ef.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-ef",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-fa.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-fa.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-fa",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-fi.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-fi.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-fi",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-nv.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-nv.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-nv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-pa.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-pa.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-pa",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-pf.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-pf.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-pf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-ql.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-ql.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-ql",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-rf.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-rf.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-rf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-sf.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-sf.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-sf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-sl.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-eortc-qlq-c30-observation-sl.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-observation-sl",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-phq-15-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-phq-15-observation.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-phq-15-observation",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "derivedFrom": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-phq-9-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-phq-9-observation.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-phq-9-observation",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "valueQuantity": {

--- a/fsh-generated/resources/Observation-mii-exa-pro-promis-depression-sf4a-raw-score.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-promis-depression-sf4a-raw-score.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-promis-depression-sf4a-raw-score",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-depression-sf4a-raw-score|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-depression-sf4a-raw-score|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-promis-depression-sf4a-tscore.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-promis-depression-sf4a-tscore.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-promis-depression-sf4a-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-depression-t-score|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-depression-t-score|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/Observation-mii-exa-pro-promis-depression-tscore-from-bdi-ii-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-promis-depression-tscore-from-bdi-ii-observation.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-promis-depression-tscore-from-bdi-ii-observation",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "valueQuantity": {

--- a/fsh-generated/resources/Observation-mii-exa-pro-whodas12-score-simple-sum.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-whodas12-score-simple-sum.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-whodas12-score-simple-sum",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
     ]
   },
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-depression-t-score.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-depression-t-score.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-depression-t-score",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     },
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-citation",

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-ap.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-ap.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-ap",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-cf.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-cf.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-cf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-co.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-co.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-co",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-di.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-di.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-di",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-dy.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-dy.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-dy",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-ef.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-ef.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-ef",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-fa.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-fa.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-fa",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-fi.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-fi.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-fi",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-nv.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-nv.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-nv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-pa.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-pa.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-pa",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-pf.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-pf.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-pf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-ql.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-ql.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-ql",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-rf.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-rf.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-rf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-sf.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-sf.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-sf",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-sl.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-eortc-qlq-c30-sl.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-eortc-qlq-c30-sl",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "code": {

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-anxiety-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-anxiety-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-anxiety-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-depression-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-depression-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-depression-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-fatigue-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-fatigue-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-fatigue-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-pain-intensity.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-pain-intensity.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-pain-intensity",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-pain-interference-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-pain-interference-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-pain-interference-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-physical-function-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-physical-function-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-physical-function-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-sleep-disturbance-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-sleep-disturbance-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-sleep-disturbance-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-social-function-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-29-social-function-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-29-social-function-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-cognitive-function-sf4a-raw-score.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-cognitive-function-sf4a-raw-score.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-cognitive-function-sf4a-raw-score",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     },
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-citation",

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-cognitive-function-sf4a-tscore.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-promis-cognitive-function-sf4a-tscore.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-promis-cognitive-function-sf4a-tscore",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     },
     {
       "url": "http://hl7.org/fhir/StructureDefinition/cqf-citation",

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-bdi-ii.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-bdi-ii.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-bdi-ii",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-anxiety-equiv.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-anxiety-equiv.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-dass21-anxiety-equiv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-anxiety-raw.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-anxiety-raw.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-dass21-anxiety-raw",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-depression-equiv.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-depression-equiv.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-dass21-depression-equiv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-depression-raw.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-depression-raw.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-dass21-depression-raw",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-stress-equiv.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-stress-equiv.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-dass21-stress-equiv",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-stress-raw.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-dass21-stress-raw.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-dass21-stress-raw",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-eq5d5l-index.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-eq5d5l-index.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-eq5d5l-index",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-eq5d5l-profile.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-eq5d5l-profile.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-eq5d5l-profile",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-eq5d5l-vas.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-eq5d5l-vas.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-eq5d5l-vas",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-phq-15.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-phq-15.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-phq-15",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-phq-9.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-phq-9.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-phq-9",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-proctcae-acs.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-proctcae-acs.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-proctcae-acs",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-proctcae-composite-grade.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-proctcae-composite-grade.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-proctcae-composite-grade",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-whodas12-simple-sum.json
+++ b/fsh-generated/resources/ObservationDefinition-mii-obsdef-pro-score-whodas12-simple-sum.json
@@ -3,13 +3,13 @@
   "id": "mii-obsdef-pro-score-whodas12-simple-sum",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint|2026.5.0"
     ]
   },
   "extension": [
     {
       "url": "http://hl7.org/fhir/StructureDefinition/artifact-version",
-      "valueString": "2026.4.1"
+      "valueString": "2026.5.0"
     }
   ],
   "category": [

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-bdi-bdi2.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-bdi-bdi2.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-bdi-bdi2",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-bdi-bdi2",
@@ -246,7 +246,7 @@
       "readOnly": true
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "de"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-ces-d.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-ces-d.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-ces-d",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-ces-d",
@@ -50,7 +50,7 @@
       "text": "This questionnaire requires proper licensing from the copyright holders. Please contact the CES-D rights holders for implementation permissions."
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-dass-dass21.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-dass-dass21.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-dass-dass21",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-dass-dass21",
@@ -3598,7 +3598,7 @@
       }
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-eortc-qlq-c30-variant-a.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-eortc-qlq-c30-variant-a.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-eortc-qlq-c30-variant-a",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-eortc-qlq-c30-variant-a",
@@ -567,7 +567,7 @@
       "text": "Calculated Scores (0-100 scale)"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-eortc-qlq-c30-variant-b.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-eortc-qlq-c30-variant-b.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-eortc-qlq-c30-variant-b",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-eortc-qlq-c30-variant-b",
@@ -54,7 +54,7 @@
       "id": "eortc-qlq-c30-cs-b",
       "meta": {
         "profile": [
-          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
         ]
       },
       "concept": [
@@ -235,7 +235,7 @@
           "display": "7 - Perfect"
         }
       ],
-      "version": "2026.4.1",
+      "version": "2026.5.0",
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-eortc-qlq-c30",
       "status": "active",
       "content": "complete",
@@ -246,7 +246,7 @@
       "id": "eortc-qlq-c30-4pt-b",
       "meta": {
         "profile": [
-          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
         ]
       },
       "compose": {
@@ -270,7 +270,7 @@
           }
         ]
       },
-      "version": "2026.4.1",
+      "version": "2026.5.0",
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-4pt-variant-b",
       "status": "active"
     },
@@ -279,7 +279,7 @@
       "id": "eortc-qlq-c30-7pt-b",
       "meta": {
         "profile": [
-          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
         ]
       },
       "compose": {
@@ -312,7 +312,7 @@
           }
         ]
       },
-      "version": "2026.4.1",
+      "version": "2026.5.0",
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-7pt-variant-b",
       "status": "active"
     }
@@ -836,7 +836,7 @@
       "text": "Calculated Scores (0-100 scale)"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-eortc-qlq-c30.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-eortc-qlq-c30.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-eortc-qlq-c30",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-eortc-qlq-c30",
@@ -54,7 +54,7 @@
       "id": "eortc-qlq-c30-cs",
       "meta": {
         "profile": [
-          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
         ]
       },
       "concept": [
@@ -235,7 +235,7 @@
           "display": "7 - Perfect"
         }
       ],
-      "version": "2026.4.1",
+      "version": "2026.5.0",
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-eortc-qlq-c30",
       "status": "active",
       "content": "complete",
@@ -246,7 +246,7 @@
       "id": "eortc-qlq-c30-4pt",
       "meta": {
         "profile": [
-          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
         ]
       },
       "compose": {
@@ -274,7 +274,7 @@
           }
         ]
       },
-      "version": "2026.4.1",
+      "version": "2026.5.0",
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-4pt",
       "status": "active"
     },
@@ -283,7 +283,7 @@
       "id": "eortc-qlq-c30-7pt",
       "meta": {
         "profile": [
-          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+          "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
         ]
       },
       "compose": {
@@ -316,7 +316,7 @@
           }
         ]
       },
-      "version": "2026.4.1",
+      "version": "2026.5.0",
       "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-7pt",
       "status": "active"
     }
@@ -840,7 +840,7 @@
       "text": "Calculated Scores (0-100 scale)"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-epds.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-epds.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-epds",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-epds",
@@ -55,7 +55,7 @@
       "text": "This questionnaire requires proper licensing from the copyright holders. Please contact the EPDS rights holders for implementation permissions."
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-answer-coding.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-answer-coding.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-euroqol-eq5d5l-answer-coding",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-euroqol-eq5d5l-answer-coding",
@@ -625,7 +625,7 @@
       "repeats": false
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "de"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-collectable.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-collectable.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-euroqol-eq5d5l-collectable",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-euroqol-eq5d5l-collectable",
@@ -1091,7 +1091,7 @@
       "repeats": false
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "de"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-displayable.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-displayable.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-euroqol-eq5d5l-displayable",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-euroqol-eq5d5l-displayable",
@@ -1203,7 +1203,7 @@
       "repeats": false
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "de"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-minimal.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-euroqol-eq5d5l-minimal.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-euroqol-eq5d5l-minimal",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-euroqol-eq5d5l-minimal",
@@ -308,7 +308,7 @@
       "text": "IHRE GESUNDHEIT HEUTE"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "de"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-hads.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-hads.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-hads",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-hads",
@@ -55,7 +55,7 @@
       "text": "This questionnaire requires proper licensing from the copyright holders. Please contact the HADS rights holders for implementation permissions."
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-k6.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-k6.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-k6",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-k6",
@@ -50,7 +50,7 @@
       "text": "This questionnaire requires proper licensing from the copyright holders. Please contact the K6 rights holders for implementation permissions."
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-midos-midos2.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-midos-midos2.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-midos-midos2",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-midos-midos2",
@@ -477,7 +477,7 @@
       "required": false
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_QST_PRO_MIDOS_MIDOS2",
   "status": "draft",
   "experimental": true,

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-phq-15.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-phq-15.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-phq-15",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-15",
@@ -593,7 +593,7 @@
       }
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-phq-9.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-phq-9.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-phq-9",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-9",
@@ -1794,7 +1794,7 @@
       }
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-pro-ctcae-breast-de.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-pro-ctcae-breast-de.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-pro-ctcae-breast-de",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-pro-ctcae-breast-de",
@@ -445,7 +445,7 @@
       "type": "group"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_QST_PRO_PRO_CTCAE_Breast_DE",
   "title": "PRO-CTCAE Deutsches Brustkrebszentrum-Subset (21 Symptome)",
   "_title": {

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-pro-ctcae-onkologisches-basisscreening.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-pro-ctcae-onkologisches-basisscreening.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-pro-ctcae-onkologisches-basisscreening",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-pro-ctcae-onkologisches-basisscreening",
@@ -298,7 +298,7 @@
       "type": "group"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_QST_PRO_PRO_CTCAE_Onkologisches_Basisscreening",
   "status": "draft",
   "experimental": true,

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-16.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-16.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-promis-16",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-promis-16",
@@ -741,7 +741,7 @@
       }
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "publisher": "Medizininformatik-Initiative (MII) – PRO Modul",
   "copyright": "The FHIR Questionnaire resource (linkIds, extensions, score calculation logic, observation extraction definitions) is part of the MII PRO Module and is licensed under CC-BY 4.0.\n\nThe PROMIS items contained herein (item text, response options, scoring algorithms, IRT parameters) are © 2008–2024 PROMIS Health Organization and PROMIS Cooperative Group. PROMIS® is a registered trademark. See https://www.healthmeasures.net for the upstream license.\n\nThe official German translations are provided by PCOR-MII (Patient-Centered Outcomes Research within the Medizininformatik-Initiative) and curated by the PROMIS National Center Germany (CPCOR, Charité – Universitätsmedizin Berlin; head: Felix Fischer).\n\nInstitutional use outside the PCOR-MII / MII context requires a usage request to CPCOR: https://cpcor.charite.de/promis_national_center_deutschland/nutzungsanfragen\n\nLOINC® codes are © Regenstrief Institute, Inc. and used under the LOINC license: https://loinc.org/license/",
   "status": "draft",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-29-de.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-29-de.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-promis-29-de",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-promis-29-de",
@@ -5360,7 +5360,7 @@
       "text": "BEREICHS-BEWERTUNGEN"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "publisher": "Medizininformatik-Initiative (MII) – PRO Modul",
   "copyright": "The FHIR Questionnaire resource (linkIds, extensions, score calculation logic, observation extraction definitions) is part of the MII PRO Module and is licensed under CC-BY 4.0.\n\nThe PROMIS items contained herein (item text, response options, scoring algorithms, IRT parameters) are © 2008–2024 PROMIS Health Organization and PROMIS Cooperative Group. PROMIS® is a registered trademark. See https://www.healthmeasures.net for the upstream license.\n\nThe official German translations are provided by PCOR-MII (Patient-Centered Outcomes Research within the Medizininformatik-Initiative) and curated by the PROMIS National Center Germany (CPCOR, Charité – Universitätsmedizin Berlin; head: Felix Fischer).\n\nInstitutional use outside the PCOR-MII / MII context requires a usage request to CPCOR: https://cpcor.charite.de/promis_national_center_deutschland/nutzungsanfragen\n\nLOINC® codes are © Regenstrief Institute, Inc. and used under the LOINC license: https://loinc.org/license/",
   "status": "active",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-29-minimal.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-29-minimal.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-promis-29-minimal",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-promis-29-minimal",
@@ -374,7 +374,7 @@
       "text": "PROMIS-29 Profile v2.1"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "de"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-29.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-29.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-promis-29",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-promis-29",
@@ -5357,7 +5357,7 @@
       "text": "BEREICHS-BEWERTUNGEN"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "publisher": "Medizininformatik-Initiative (MII) – PRO Modul",
   "copyright": "The FHIR Questionnaire resource (linkIds, extensions, score calculation logic, observation extraction definitions) is part of the MII PRO Module and is licensed under CC-BY 4.0.\n\nThe PROMIS items contained herein (item text, response options, scoring algorithms, IRT parameters) are © 2008–2024 PROMIS Health Organization and PROMIS Cooperative Group. PROMIS® is a registered trademark. See https://www.healthmeasures.net for the upstream license.\n\nThe official German translations are provided by PCOR-MII (Patient-Centered Outcomes Research within the Medizininformatik-Initiative) and curated by the PROMIS National Center Germany (CPCOR, Charité – Universitätsmedizin Berlin; head: Felix Fischer).\n\nInstitutional use outside the PCOR-MII / MII context requires a usage request to CPCOR: https://cpcor.charite.de/promis_national_center_deutschland/nutzungsanfragen\n\nLOINC® codes are © Regenstrief Institute, Inc. and used under the LOINC license: https://loinc.org/license/",
   "status": "active",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-cognitive-function-sf4a.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-cognitive-function-sf4a.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-promis-cognitive-function-sf4a",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-promis-cognitive-function-sf4a",
@@ -922,7 +922,7 @@
       "text": "PROMIS Kognitive Funktion SF 4a"
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "publisher": "Medizininformatik-Initiative (MII) – PRO Modul",
   "copyright": "The FHIR Questionnaire resource (linkIds, extensions, score calculation logic, observation extraction definitions) is part of the MII PRO Module and is licensed under CC-BY 4.0.\n\nThe PROMIS items contained herein (item text, response options, scoring algorithms, IRT parameters) are © 2008–2024 PROMIS Health Organization and PROMIS Cooperative Group. PROMIS® is a registered trademark. See https://www.healthmeasures.net for the upstream license.\n\nThe official German translations are provided by PCOR-MII (Patient-Centered Outcomes Research within the Medizininformatik-Initiative) and curated by the PROMIS National Center Germany (CPCOR, Charité – Universitätsmedizin Berlin; head: Felix Fischer).\n\nInstitutional use outside the PCOR-MII / MII context requires a usage request to CPCOR: https://cpcor.charite.de/promis_national_center_deutschland/nutzungsanfragen\n\nLOINC® codes are © Regenstrief Institute, Inc. and used under the LOINC license: https://loinc.org/license/",
   "status": "active",

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-depression-sf4a.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-promis-depression-sf4a.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-promis-depression-sf4a",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-promis-depression-sf4a",
@@ -876,7 +876,7 @@
       "readOnly": true
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en"

--- a/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
+++ b/fsh-generated/resources/Questionnaire-mii-qst-pro-whodas-whodas12.json
@@ -3,7 +3,7 @@
   "id": "mii-qst-pro-whodas-whodas12",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire|2026.5.0"
     ]
   },
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12",
@@ -491,7 +491,7 @@
       }
     }
   ],
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "status": "active",
   "experimental": true,
   "language": "en",

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-bdi-bdi2.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-bdi-bdi2.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-bdi-bdi2",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "subject": {

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-dass-dass21-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-dass-dass21-response-01.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-dass-dass21-response-01",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "subject": {

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-eortc-qlq-c30-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-eortc-qlq-c30-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-eortc-qlq-c30-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "subject": {

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-euroqol-eq5d5l-coded-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-euroqol-eq5d5l-coded-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-euroqol-eq5d5l-coded-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-euroqol-eq5d5l-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-euroqol-eq5d5l-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-euroqol-eq5d5l-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-midos2-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-midos2-response-01.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-midos2-response-01",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "subject": {

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-phq-15-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-phq-15-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-phq-15-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-phq-9-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-phq-9-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-phq-9-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-pro-ctcae-onkologisches-basisscreening-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-pro-ctcae-onkologisches-basisscreening-response-01.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-pro-ctcae-onkologisches-basisscreening-response-01",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "subject": {

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-promis-29-de-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-promis-29-de-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-promis-29-de-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-promis-29-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-promis-29-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-promis-29-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-promis-depression-sf4a-response.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-promis-depression-sf4a-response.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-promis-depression-sf4a-response",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "item": [

--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-whodas12-response-01",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.4.1"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response|2026.5.0"
     ]
   },
   "subject": {

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-code.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-code.json
@@ -35,7 +35,7 @@
     "ObservationDefinition"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_ObservationDefinition_Code",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-health-correlation.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-health-correlation.json
@@ -35,7 +35,7 @@
     "ObservationDefinition"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_ObservationDefinition_ScoreHealthCorrelation",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-interval-category.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-interval-category.json
@@ -35,7 +35,7 @@
     "ObservationDefinition"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_ObservationDefinition_QualifiedInterval_Category",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-permitted-datatype.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-permitted-datatype.json
@@ -35,7 +35,7 @@
     "ObservationDefinition"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_ObservationDefinition_PermittedDataType",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-preferred-report-name.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-preferred-report-name.json
@@ -35,7 +35,7 @@
     "ObservationDefinition"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_ObservationDefinition_PreferredReportName",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-unit.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-observationdefinition-unit.json
@@ -35,7 +35,7 @@
     "ObservationDefinition"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_ObservationDefinition_QuantitativeDetails_Unit",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/SearchParameter-mii-sp-pro-questionnaire-capabilities.json
+++ b/fsh-generated/resources/SearchParameter-mii-sp-pro-questionnaire-capabilities.json
@@ -35,7 +35,7 @@
     "Questionnaire"
   ],
   "publisher": "Medizininformatik Initiative",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_SP_PRO_Questionnaire_Capabilities",
   "status": "active",
   "experimental": true,

--- a/fsh-generated/resources/StructureDefinition-mii-ex-pro-questionnaire-capabilities.json
+++ b/fsh-generated/resources/StructureDefinition-mii-ex-pro-questionnaire-capabilities.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-ex-pro-questionnaire-capabilities",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-questionnaire-capabilities",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Questionnaire_Capabilities",
   "title": "MII PR PRO Questionnaire Capabilities",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-ex-pro-score-score-health-correlation.json
+++ b/fsh-generated/resources/StructureDefinition-mii-ex-pro-score-score-health-correlation.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-ex-pro-score-score-health-correlation",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-ex-pro-score-score-health-correlation",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_EX_PRO_Score_Score_Health_Correlation",
   "title": "MII Ex PRO Score Score Health Correlation",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-lm-pro.json
+++ b/fsh-generated/resources/StructureDefinition-mii-lm-pro.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-lm-pro",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-lm-pro",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_LM_PRO",
   "title": "MII Logical Model Modul PRO - Patient-Reported Outcomes und abgeleitete Metriken",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-depression-t-score.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-depression-t-score.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-depression-t-score",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-depression-t-score",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Depression_T_Score",
   "title": "MII PR PRO Depression Domain T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-bdi-ii.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-bdi-ii.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-observation-bdi-ii",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-bdi-ii",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Observation_BDI_II",
   "title": "MII PR PRO Observation BDI-II",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-eq5d5l-index.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-eq5d5l-index.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-observation-eq5d5l-index",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-eq5d5l-index",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Observation_EQ5D5L_Index",
   "title": "MII PR PRO Observation EQ-5D-5L Index",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-eq5d5l-profile.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-eq5d5l-profile.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-observation-eq5d5l-profile",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-eq5d5l-profile",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Observation_EQ5D5L_Profile",
   "title": "MII PR PRO Observation EQ-5D-5L Profile",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-eq5d5l-vas.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-eq5d5l-vas.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-observation-eq5d5l-vas",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-eq5d5l-vas",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Observation_EQ5D5L_VAS",
   "title": "MII PR PRO Observation EQ-5D-5L VAS",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-anxiety-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-anxiety-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-anxiety-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-anxiety-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Anxiety_TScore",
   "title": "MII PR PRO PROMIS-29 Anxiety T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-depression-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-depression-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-depression-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-depression-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Depression_TScore",
   "title": "MII PR PRO PROMIS-29 Depression T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-fatigue-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-fatigue-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-fatigue-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-fatigue-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Fatigue_TScore",
   "title": "MII PR PRO PROMIS-29 Fatigue T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-pain-intensity.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-pain-intensity.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-pain-intensity",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-pain-intensity",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Pain_Intensity",
   "title": "MII PR PRO PROMIS-29 Pain Intensity",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-pain-interference-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-pain-interference-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-pain-interference-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-pain-interference-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Pain_Interference_TScore",
   "title": "MII PR PRO PROMIS-29 Pain Interference T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-physical-function-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-physical-function-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-physical-function-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-physical-function-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Physical_Function_TScore",
   "title": "MII PR PRO PROMIS-29 Physical Function T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-sleep-disturbance-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-sleep-disturbance-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-sleep-disturbance-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-sleep-disturbance-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Sleep_Disturbance_TScore",
   "title": "MII PR PRO PROMIS-29 Sleep Disturbance T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-social-function-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-29-social-function-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-29-social-function-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-29-social-function-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_29_Social_Function_TScore",
   "title": "MII PR PRO PROMIS-29 Social Function T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-cognitive-function-sf4a-raw-score.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-cognitive-function-sf4a-raw-score.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-cognitive-function-sf4a-raw-score",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-cognitive-function-sf4a-raw-score",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_Cognitive_Function_SF4a_Raw_Score",
   "title": "MII PR PRO PROMIS Cognitive Function SF 4a Raw Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-cognitive-function-sf4a-tscore.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-cognitive-function-sf4a-tscore.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-cognitive-function-sf4a-tscore",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-cognitive-function-sf4a-tscore",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_Cognitive_Function_SF4a_TScore",
   "title": "MII PR PRO PROMIS Cognitive Function SF 4a T-Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-depression-sf4a-raw-score.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-promis-depression-sf4a-raw-score.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-promis-depression-sf4a-raw-score",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-promis-depression-sf4a-raw-score",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_PROMIS_Depression_SF4a_Raw_Score",
   "title": "MII PR PRO PROMIS Depression SF 4a Raw Score",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-questionnaire-response.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-questionnaire-response.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-questionnaire-response",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire-response",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_QuestionnaireResponse",
   "title": "MII PR PRO QuestionnaireResponse",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-questionnaire.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-questionnaire.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-questionnaire",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-questionnaire",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Questionnaire",
   "title": "MII PR PRO Questionnaire",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-score-blueprint.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-score-blueprint.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-score-blueprint",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-blueprint",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Score_Blueprint",
   "title": "MII PR PRO Score Blueprint / Template",
   "status": "active",

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-score-instance.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-score-instance.json
@@ -2,7 +2,7 @@
   "resourceType": "StructureDefinition",
   "id": "mii-pr-pro-score-instance",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "name": "MII_PR_PRO_Score_Instance",
   "title": "MII PR PRO Score Instance",
   "status": "active",

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-bdi-bdi2-long.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-bdi-bdi2-long.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO BDI-II",
   "description": "MII VS PRO BDI-II ValueSet for Beck Depression Inventory II (BDI-II) Questionnaire",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-bdi-bdi2-long",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-bdi-bdi2-short.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-bdi-bdi2-short.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO BDI-II",
   "description": "MII VS PRO BDI-II ValueSet for Beck Depression Inventory II (BDI-II) Questionnaire",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-bdi-bdi2-short",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-dass-21-answer-list.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-dass-21-answer-list.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO DASS-21 Answer List",
   "description": "4-point Likert response scale for all DASS-21 items (0 = Did not apply to me at all, 3 = Applied to me very much)",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-dass-21-answer-list",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-eortc-qlq-c30-scale-4pt.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-eortc-qlq-c30-scale-4pt.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO EORTC QLQ-C30 4-Point Scale",
   "description": "Standard 4-point response scale for EORTC QLQ-C30 items",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-4pt",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-eortc-qlq-c30-scale-7pt.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-eortc-qlq-c30-scale-7pt.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO EORTC QLQ-C30 7-Point Scale",
   "description": "7-point response scale for EORTC QLQ-C30 global health status and quality of life items",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-7pt",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-eortc-qlq-c30-scale-role.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-eortc-qlq-c30-scale-role.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO EORTC QLQ-C30 Role Functioning Scale",
   "description": "4-point response scale for EORTC QLQ-C30 role functioning items",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-eortc-qlq-c30-scale-role",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-midos2-severity.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-midos2-severity.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO MIDOS2 DGP-Severity-Skala",
   "description": "DGP-4-stufige Severity-Skala (keine, leichte, mittlere, starke) — wird für die 11 Symptom-Items des MIDOS2 verwendet.",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-midos2-severity",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-midos2-wellbeing.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-midos2-wellbeing.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO MIDOS2 Wohlbefinden-Skala",
   "description": "4-stufige Wohlbefinden-Skala (sehr gut, eher gut, eher schlecht, sehr schlecht) — wird für das Wohlbefinden-Item des MIDOS2 verwendet.",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-midos2-wellbeing",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-phq-15-answers.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-phq-15-answers.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PHQ-15 Answers",
   "description": "PHQ-15 somatic symptom bother severity answer options (0 = Nicht beeinträchtigt, 1 = Wenig beeinträchtigt, 2 = Stark beeinträchtigt). MII-controlled for reliable ordinal() score calculation.",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-phq-15-answers",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "compose": {
     "include": [
       {

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-phq-9-answer-list-ll358-3.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-phq-9-answer-list-ll358-3.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PHQ-9 Answer List LL358-3",
   "description": "Patient Health Questionnaire (PHQ-9) Not at all/Several days/More than half the days/Nearly every day",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-phq-9-answer-list-ll358-3",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": false,
   "language": "de",
   "compose": {

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-phq-9-answer-list-ll359-1.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-phq-9-answer-list-ll359-1.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PHQ-9 Answer List LL359-1",
   "description": "Not difficult at all/Somewhat difficult/Very difficult/Extremely difficult-Perceived difficulty (PHQ-9)",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-phq-9-answer-list-ll359-1",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": false,
   "language": "de",
   "compose": {

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-frequency-sexual.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-frequency-sexual.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Frequency Scale (Sexual Function)",
   "description": "7-point frequency scale for sexual function items: standard 5 options plus 'Not sexually active' and 'Prefer not to answer'",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-frequency-sexual",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-frequency.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-frequency.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Frequency Scale",
   "description": "5-point frequency response scale for PRO-CTCAE items (0=Never, 4=Almost constantly)",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-frequency",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-interference.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-interference.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Interference Scale",
   "description": "5-point interference response scale for PRO-CTCAE items (0=Not at all, 4=Very much)",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-interference",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-presence-na.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-presence-na.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Presence Scale (with Not Applicable)",
   "description": "3-option presence scale: Yes / No / Not applicable",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-presence-na",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-presence-sexual.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-presence-sexual.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Presence Scale (Sexual Function)",
   "description": "4-option presence scale for sexual function: Yes / No / Not sexually active / Prefer not to answer",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-presence-sexual",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-presence.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-presence.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Presence Scale",
   "description": "Binary presence/absence response scale for PRO-CTCAE items",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-presence",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-severity-radiation.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-severity-radiation.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Severity Scale (Radiation)",
   "description": "6-point severity scale for radiation items: standard 5 options plus 'Not applicable'",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-severity-radiation",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-severity-sexual.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-severity-sexual.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Severity Scale (Sexual Function)",
   "description": "7-point severity scale for sexual function items: standard 5 options plus 'Not sexually active' and 'Prefer not to answer'",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-severity-sexual",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-severity.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-pro-ctcae-severity.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PRO-CTCAE Severity Scale",
   "description": "5-point severity response scale for PRO-CTCAE items (0=None, 4=Very severe)",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-pro-ctcae-severity",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-promis-frequency-response-scale.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-promis-frequency-response-scale.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PROMIS Frequency Response Scale",
   "description": "PROMIS Frequency response scale based on LOINC LL1016-6",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-promis-frequency-response-scale",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "language": "en",
   "compose": {

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-promis-intensity-response-scale.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-promis-intensity-response-scale.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PROMIS Intensity Response Scale",
   "description": "PROMIS Intensity response scale (Not at all / A little bit / Somewhat / Quite a bit / Very much) based on LOINC LL1024-0",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-promis-intensity-response-scale",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "language": "en",
   "compose": {

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-promis-physical-function-response-scale.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-promis-physical-function-response-scale.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO PROMIS Physical Function Response Scale",
   "description": "PROMIS Physical Function response scale based on LOINC LL1022-4",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-promis-physical-function-response-scale",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "language": "en",
   "compose": {

--- a/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
+++ b/fsh-generated/resources/ValueSet-mii-vs-pro-whodas-12-answer-list.json
@@ -6,7 +6,7 @@
   "title": "MII VS PRO WHODAS 2.0 12-Item Answer List",
   "description": "5-point response scale for all WHODAS-12 items (0 = None, 1 = Mild, 2 = Moderate, 3 = Severe, 4 = Extreme or cannot do). MII-controlled for reliable ordinal() score calculation; German labels via designations on mii-cs-pro-whodas-12.",
   "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ValueSet/mii-vs-pro-whodas-12-answer-list",
-  "version": "2026.4.1",
+  "version": "2026.5.0",
   "experimental": true,
   "compose": {
     "include": [
@@ -27,78 +27,6 @@
           },
           {
             "code": "whodas12-answer-4"
-          }
-        ]
-      }
-    ]
-  },
-  "expansion": {
-    "identifier": "urn:uuid:mii-pro-expansion-1783407037498",
-    "timestamp": "2026-07-07T06:50:37.468Z",
-    "total": 5,
-    "parameter": [
-      {
-        "name": "mii-pro-version",
-        "valueString": "2026.4.1"
-      },
-      {
-        "name": "expandedAt",
-        "valueDateTime": "2026-07-07T06:50:37.468Z"
-      }
-    ],
-    "contains": [
-      {
-        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-        "code": "whodas12-answer-0",
-        "display": "None",
-        "designation": [
-          {
-            "language": "de",
-            "value": "keine"
-          }
-        ]
-      },
-      {
-        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-        "code": "whodas12-answer-1",
-        "display": "Mild",
-        "designation": [
-          {
-            "language": "de",
-            "value": "geringe"
-          }
-        ]
-      },
-      {
-        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-        "code": "whodas12-answer-2",
-        "display": "Moderate",
-        "designation": [
-          {
-            "language": "de",
-            "value": "mäßige"
-          }
-        ]
-      },
-      {
-        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-        "code": "whodas12-answer-3",
-        "display": "Severe",
-        "designation": [
-          {
-            "language": "de",
-            "value": "starke"
-          }
-        ]
-      },
-      {
-        "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-        "code": "whodas12-answer-4",
-        "display": "Extreme or cannot do",
-        "designation": [
-          {
-            "language": "de",
-            "value": "sehr starke/nicht möglich"
           }
         ]
       }

--- a/input/fsh/rulesets/version.fsh
+++ b/input/fsh/rulesets/version.fsh
@@ -15,20 +15,20 @@
 
 // For Questionnaire instances (native FHIR R4 element)
 RuleSet: Version
-* version = "2026.4.1"
+* version = "2026.5.0"
 
 // For Profile, CodeSystem, ValueSet, Extension definitions (caret notation)
 RuleSet: PR_CS_VS_Version
-* ^version = "2026.4.1"
+* ^version = "2026.5.0"
 
 // For ObservationDefinition instances (R4 backport of R5 version element)
 // ObservationDefinition lacks native version in R4; added in R5
 // See: https://hl7.org/fhir/extensions/StructureDefinition-artifact-version.html
 RuleSet: ObsDefVersion
 * extension[+].url = "http://hl7.org/fhir/StructureDefinition/artifact-version"
-* extension[=].valueString = "2026.4.1"
+* extension[=].valueString = "2026.5.0"
 
 // For all instances to declare profile conformance with versioned canonical
-// Generates: meta.profile = "{canonical}|2026.4.1"
+// Generates: meta.profile = "{canonical}|2026.5.0"
 RuleSet: MetaProfile(canonical)
-* meta.profile[+] = "{canonical}|2026.4.1"
+* meta.profile[+] = "{canonical}|2026.5.0"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,5 +1,30 @@
 Diese Seite dokumentiert die Änderungen zwischen den Versionen des MII PRO-Moduls.
 
+**Version: 2026.5.0**
+
+Datum: 2026-07-07 (in Vorbereitung)
+
+Minor-Release: zwei neue Instrumente (**WHODAS 2.0 12-Item** und **PHQ-15**), Aufbau einer gemeinsamen **PHQ-D-Itembank** (PHQ-9/PHQ-15), einheitliche **MII-Score-Codierung** über alle Score-ObsDefs und eine **CI-Verbesserung** (ValueSet-Expansion), die die answerValueSet-Antwortvalidierung dauerhaft korrigiert.
+
+## Neue Instrumente
+
+- Added: **WHODAS 2.0 12-Item (Selbstauskunft)** — WHO Disability Assessment Schedule 2.0, 12 Items über 6 ICF-Domänen, 30-Tage-Recall, 5-stufige Skala (0–4). Englisch primär mit deutschen Translations (validierte PCOR-MII-Wortlaute). Antworten via `answerValueSet` (`mii-vs-pro-whodas-12-answer-list`) mit ordinalValue-Gewichten auf den CodeSystem-Konzepten. **Einschränkungsscore** `mii-obsdef-pro-score-whodas12-simple-sum` (0–48, SNOMED `715823002`, MII-Katalog `whodas12-simple-sum`, höher = mehr Beeinträchtigung). Inkl. Beispiel-QuestionnaireResponse + Score-Observation und IG-Seite.
+  - **Lizenz:** WHODAS 2.0 © WHO 2010. Die Bedingungen sind maschinenlesbar als `copyright` auf Questionnaire und CodeSystem hinterlegt: kostenfreie Kliniker-Eigennutzung; elektronische/Datenerfassungs-Nutzung erfordert eine (für nicht-kommerzielle Nutzung kostenlose) WHO-Nutzungsvereinbarung; Übersetzungen erfordern WHO-Genehmigung; MII-FHIR-Inhalte CC0, WHODAS-Itemtext © WHO.
+- Added: **PHQ-15** (Gesundheitsfragebogen für Patienten, somatische Symptomlast, PHQ-D) — 15 Items, 4-Wochen-Recall, 3-stufige Skala (0–2). Englisch primär mit deutschen Translations (PHQ-D, Löwe et al. 2002). Antworten via `answerValueSet` mit ordinalValue-Gewichten. Score `mii-obsdef-pro-score-phq-15` (0–30, LOINC `70273-8`) inkl. **Schweregrad-Kategorien** (Kroenke et al. 2002: 0–4 / 5–9 / 10–14 / 15–30) als `qualifiedInterval`-Reference-Ranges. Inkl. IG-Seite. Lizenz: frei verfügbar (public domain), PHQ-D.
+
+## Architektur: PHQ-D-Itembank
+
+- Changed: **PHQ-9 und PHQ-15 nutzen ein gemeinsames PHQ-D-Block-LinkId-Schema** (`phq-phq…`). Die in beiden Instrumenten enthaltenen Items (Schlaf `phq-phq2c`, Müdigkeit `phq-phq2d`) teilen sich denselben linkId — Grundlage für item-basiertes Scoring über Instrumente hinweg.
+- Changed: PHQ-15 auf `answerValueSet` + CodeSystem-`ordinalValue` (EN-first) umgestellt; `copyright`/Lizenz-Status auf PHQ-Ressourcen explizit gesetzt.
+
+## Scoring & Terminologie
+
+- Changed: **MII-Katalog-Code (`code.coding[mii]`) auf allen Score-ObservationDefinitions** ergänzt (PROMIS-29 ×8, PROMIS Cognitive Function SF4a, Depression-T-Score, BDI-II, PHQ-9, PHQ-15) — zusätzlich zu LOINC/SNOMED, einheitlich über den MII-Score-Catalogue abfragbar (zuvor bereits EQ-5D/EORTC/DASS-21/PRO-CTCAE).
+
+## Technische Verbesserungen
+
+- Changed: **CI** — `expand-valuesets.js` läuft jetzt nach SUSHI im IG-Build (`ig-publisher.yml`) und schreibt `vs.expansion` aus lokalen CodeSystems. Dadurch kann der Validator die MII-kontrollierten `answerValueSet`-Antwortskalen auflösen; die zuvor gemeldeten „Wert nicht in den angegebenen Optionen"-Findings auf Beispiel-QuestionnaireResponses entfallen (PHQ-15, WHODAS und künftige answerValueSet-Instrumente).
+
 **Version: 2026.4.1**
 
 Datum: 2026-06-15 (released, Tag `v2026.4.1`)

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -2,8 +2,8 @@ Die vorliegende Spezifikation des Moduls PROs, PROMs und abgeleitete Metriken be
 
 | Veröffentlichung |   |
 |---------|---|
-| Datum   | 30.03.2026 |
-| Version | 2026.4.1   |
+| Datum   | 07.07.2026 |
+| Version | 2026.5.0   |
 | Status  | active     |
 | Realm   | DE         |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "de.medizininformatikinitiative.kerndatensatz.pros",
-  "version": "2026.4.1",
-  "description": "MII PRO Module v2026.4.1 - Patch-Release: artifact-version-Extension für 3 EQ-5D-5L ObservationDefinitions nachgezogen (Index/Profile/VAS) — vorher fehlte Versions-Metadatum auf diesen Resourcen. Aufbauend auf v2026.4.0: PROMIS-Konsolidierung + Symptom-Screening. Release Notes: https://simplifier.net/guide/mii-pro-v2026-de/MIIIGModulPRO/Release-Notes",
+  "version": "2026.5.0",
+  "description": "MII PRO Module v2026.5.0 - Neue Instrumente WHODAS 2.0 12-Item (Einschränkungsscore, mit korrekten WHO-Lizenzbedingungen) und PHQ-15 (somatische Symptomlast, PHQ-D); PHQ-9/PHQ-15 auf gemeinsames PHQ-D-Block-LinkId-Schema; MII-Katalog-Codes (code.coding[mii]) auf allen Score-ObsDefs; ValueSet-Expansion im IG-Build (answerValueSet-Validierung). Release Notes: https://simplifier.net/guide/mii-pro-v2026-de/MIIIGModulPRO/Release-Notes",
   "keywords": [
     "MII",
     "KDS",

--- a/qc/custom.rules.yaml
+++ b/qc/custom.rules.yaml
@@ -21,7 +21,7 @@
   filter: (StructureDefinition or ValueSet or CodeSystem or ConceptMap or StructureMap or NamingSystem or SearchParameter or CapabilityStatement or OperationDefinition or ImplementationGuide).exists()
   # Excluding NamingSystem as they have no version
   status: "Checking if all resources have version filled"
-  predicate: version.exists() and (version in ('2026.0.0-rc.1', '2026.0.0-rc.2', '2026.0.0-rc.3', '2026.0.0-rc.4', '2026.0.0-ballot', '2026.0.0', '2026.0.1', '2026.1.0', '2026.2.0'))
+  predicate: version.exists() and (version in ('2026.0.0-rc.1', '2026.0.0-rc.2', '2026.0.0-rc.3', '2026.0.0-rc.4', '2026.0.0-ballot', '2026.0.0', '2026.0.1', '2026.1.0', '2026.2.0', '2026.3.0', '2026.4.0', '2026.4.1', '2026.5.0'))
   error-message: "version not filled (correctly)"
   files:
     - /**/*.xml

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: MII_IG_PRO
 title: "MII IG PRO"
 description: "Medizininformatik Initiative - Modul PROs, PROMs und abgeleitete Metriken"
 status: active # draft | active | retired | unknown
-version: 2026.4.1
+version: 2026.5.0
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 packageId: de.medizininformatikinitiative.kerndatensatz.pros
 copyrightYear: 2025+


### PR DESCRIPTION
## Release v2026.5.0

Minor-Release. Quell-Version-Bump `2026.4.1` → `2026.5.0` (`version.fsh`, `sushi-config.yaml`, `package.json`, `qc/custom.rules.yaml`) + Release-Notes (`changes.md`). `fsh-generated` wird vom CI auf 2026.5.0 regeneriert.

### Inhalt (seit v2026.4.1)
- **Neue Instrumente:** WHODAS 2.0 12-Item (Einschränkungsscore 0–48, **mit korrekten WHO-Lizenzbedingungen** als `copyright`) und PHQ-15 (somatische Symptomlast, PHQ-D, Score 0–30 + Kroenke-Schweregrade).
- **PHQ-D-Itembank:** PHQ-9 + PHQ-15 auf gemeinsames Block-LinkId-Schema (geteilte Items Schlaf/Müdigkeit).
- **Scoring:** MII-Katalog-Code (`code.coding[mii]`) auf allen Score-ObsDefs (PROMIS-29, Cognitive-SF4a, Depression-T-Score, BDI-II, PHQ-9/15).
- **CI:** ValueSet-Expansion (`expand-valuesets.js`) im IG-Build → answerValueSet-Antwortvalidierung sauber.

Enthält bereits gemergte PRs #103, #104, #105, #106.

### Nach dem Merge (Phase 5+)
- [ ] Tag `v2026.5.0` setzen (triggert Draft-GitHub-Release)
- [ ] Package auf Simplifier publizieren + `.tgz` an Release anhängen
- [ ] IG exportieren / TMF-SharePoint

Lokale Verifikation: `sushi .` → 0 Errors / 0 Warnings; Version in Questionnaire.version, `meta.profile|2026.5.0`, ObsDef `artifact-version`, CS.version bestätigt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)