### PR TITLE
docs(simplifier): PRO-Bibliothek-Seiten für PHQ-15 und WHODAS 2.0

### DIFF
--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/PHQ-15/Index.page.md
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/PHQ-15/Index.page.md
@@ -1,0 +1,81 @@
+---
+topic: PHQ-15
+---
+## PHQ-15 (Patient Health Questionnaire-15)
+
+### Klinischer Kontext
+
+Der PHQ-15 ist ein validiertes Screening-Instrument für die Schwere **somatischer Symptome**. Er erfasst die Beeinträchtigung durch 15 körperliche Beschwerden über einen Zeitraum von vier Wochen auf einer dreistufigen Skala (0 = nicht, 1 = wenig, 2 = stark beeinträchtigt).
+
+**Scoring und Interpretation** (Summenwert 0–30, Kroenke et al. 2002):
+- 0–4: Minimale somatische Symptomlast
+- 5–9: Geringe somatische Symptomlast
+- 10–14: Mittlere somatische Symptomlast
+- ≥15: Hohe somatische Symptomlast
+
+**Zusammenhang mit der PHQ-Familie:** Zwei der 15 Items (Müdigkeit, Schlaf) stammen aus dem Depressionsmodul (PHQ-9). Im MII-PRO-Modul teilen sie sich über den gemeinsamen PHQ-D-Itembank-Namespace denselben linkId (`phq-phq2d` Müdigkeit, `phq-phq2c` Schlaf) — dieselben linkIds wie im PHQ-9.
+
+### FHIR-Implementierung
+
+> **Sprachstrategie:** Englisch als Primärsprache (Original-Instrument), deutsche Texte als Translations (PHQ-D, Löwe et al. 2002). Gewährleistet korrekte Validierung gegen LOINC.
+
+#### Questionnaire
+
+**Canonical URL:** `https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-15`
+
+**Implementierte Capabilities:**
+- ✅ Displayable, Collectable, Calculatable, Extractable, Domain-aligned
+
+**Besonderheiten:**
+- Antwortskala über `answerValueSet` (`mii-vs-pro-phq-15-answers`); ordinale Gewichte (0/1/2) als Property auf den CodeSystem-Konzepten (`mii-cs-pro-phq-15-answers`).
+- Automatische Score-Berechnung via FHIRPath: `%resource.item.where(linkId.matches('^phq-phq(1[a-m]|2[cd])$')).answer.value.ordinal().sum()`.
+- linkIds im gemeinsamen PHQ-D-Block-Namespace; LOINC-Panel `69728-4`, Items LOINC-kodiert.
+
+<tabs>
+  <tab title="Vorschau">
+    <iframe
+      src="https://gematik.github.io/poc-isik-formular/?base=https://fhir.simplifier.net/MII-Erweiterungsmodul-PRO-2025&id=mii-qst-pro-phq-15&minimal=true"
+      width="100%"
+      height="600px"
+      frameborder="0">
+    </iframe>
+  </tab>
+  <tab title="Tree">
+    {{tree:https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-15}}
+  </tab>
+  <tab title="JSON">
+    {{json:https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-15}}
+  </tab>
+  <tab title="XML">
+    {{xml:https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-15}}
+  </tab>
+</tabs>
+
+#### Score-Repräsentation
+
+1. **Als berechnetes Item** in der QuestionnaireResponse (linkId: `phq-phq15-score-total`)
+2. **Als Observation** mit LOINC-Code `70273-8` „Patient Health Questionnaire 15 item (PHQ-15) total score"
+3. **ObservationDefinition:** `mii-obsdef-pro-score-phq-15` — Wertebereich 0–30 {score}, höher = größere somatische Symptomlast, inkl. Schweregrad-Referenzbereiche (Kroenke-Cut-offs) als `qualifiedInterval`.
+
+### Beispiel-Ressourcen
+
+<tabs>
+  <tab title="Tree">
+    {{tree:mii-exa-pro-phq-15-response}}
+  </tab>
+  <tab title="JSON">
+    {{json:mii-exa-pro-phq-15-response}}
+  </tab>
+  <tab title="XML">
+    {{xml:mii-exa-pro-phq-15-response}}
+  </tab>
+</tabs>
+
+### Lizenz
+
+PHQ / PHQ-15 © Pfizer Inc. — **frei verfügbar** (public domain), keine Genehmigung für Reproduktion/Übersetzung/Nutzung erforderlich. Deutsche Fassung: PHQ-D (Löwe, Spitzer, Zipfel & Herzog 2002).
+
+### Referenzen
+
+- Kroenke K, Spitzer RL, Williams JBW. The PHQ-15: validity of a new measure for evaluating the severity of somatic symptoms. *Psychosomatic Medicine* 2002;64(2):258–266.
+- Gräfe K, Zipfel S, Herzog W, Löwe B. Screening psychischer Störungen mit dem „Gesundheitsfragebogen für Patienten (PHQ-D)". *Diagnostica* 2004;50(4):171–181.

--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/PHQ-15/toc.yaml
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/PHQ-15/toc.yaml
@@ -1,0 +1,2 @@
+- name: Index
+  filename: Index.page.md

--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/WHODAS-2.0/Index.page.md
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/WHODAS-2.0/Index.page.md
@@ -1,0 +1,87 @@
+---
+topic: WHODAS 2.0 (12-Item)
+---
+## WHODAS 2.0 (12-Item, Selbstauskunft)
+
+### Klinischer Kontext
+
+Der **WHODAS 2.0** (WHO Disability Assessment Schedule 2.0) ist das generische Instrument der WHO zur Erfassung von **Funktionsfähigkeit und Beeinträchtigung** über alle Erkrankungen hinweg, methodisch an der ICF ausgerichtet. Diese Implementierung nutzt die **12-Item-Kurzform (Selbstauskunft)**.
+
+Die 12 Items decken **sechs ICF-Domänen** ab (Kognition, Mobilität, Selbstversorgung, Umgang mit anderen Menschen, Lebensaktivitäten, Partizipation), erfassen die Beeinträchtigung der **letzten 30 Tage** auf einer fünfstufigen Skala (0 = keine … 4 = extreme Beeinträchtigung / nicht möglich).
+
+**Scoring und Interpretation** (Summenwert 0–48):
+- Einfaches Scoring (WHO „simple scoring"): Summe der 12 Item-Werte (je 0–4), Wertebereich **0–48**.
+- **Höhere Werte = stärkere Beeinträchtigung** (Einschränkungsscore).
+- Die komplexe, IRT-basierte WHO-Bewertung (0–100) ist noch nicht abgebildet (Folgearbeit).
+
+PCOR-MII führt WHODAS-12 unter „Generic Health" gemeinsam mit PROMIS Global Health; eine Konversion des Summenscores auf die PROMIS Generic/Global Health Scale ist als Folgearbeit vorgesehen.
+
+### FHIR-Implementierung
+
+> **Sprachstrategie:** Englisch als Primärsprache (Original-Instrument), deutsche Texte als Translations/Designations (validierte PCOR-MII-Wortlaute).
+
+#### Questionnaire
+
+**Canonical URL:** `https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12`
+
+**Implementierte Capabilities:**
+- ✅ Displayable, Collectable, Calculatable, Extractable, Domain-aligned
+
+**Besonderheiten:**
+- Antwortskala über `answerValueSet` (`mii-vs-pro-whodas-12-answer-list`); ordinale Gewichte (0–4) als Property auf den CodeSystem-Konzepten (`mii-cs-pro-whodas-12`).
+- Automatische Score-Berechnung via FHIRPath (`.ordinal().sum()`).
+
+<tabs>
+  <tab title="Vorschau">
+    <iframe
+      src="https://gematik.github.io/poc-isik-formular/?base=https://fhir.simplifier.net/MII-Erweiterungsmodul-PRO-2025&id=mii-qst-pro-whodas-whodas12&minimal=true"
+      width="100%"
+      height="600px"
+      frameborder="0">
+    </iframe>
+  </tab>
+  <tab title="Tree">
+    {{tree:https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12}}
+  </tab>
+  <tab title="JSON">
+    {{json:https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12}}
+  </tab>
+  <tab title="XML">
+    {{xml:https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-whodas-whodas12}}
+  </tab>
+</tabs>
+
+#### Score-Repräsentation
+
+- **ObservationDefinition:** `mii-obsdef-pro-score-whodas12-simple-sum` — Wertebereich 0–48, SNOMED `715823002`, MII-Score-Catalogue `whodas12-simple-sum`, Richtung: höher = größere Beeinträchtigung.
+
+### Beispiel-Ressourcen
+
+<tabs>
+  <tab title="Tree">
+    {{tree:mii-exa-pro-whodas12-response-01}}
+  </tab>
+  <tab title="JSON">
+    {{json:mii-exa-pro-whodas12-response-01}}
+  </tab>
+  <tab title="XML">
+    {{xml:mii-exa-pro-whodas12-response-01}}
+  </tab>
+</tabs>
+
+### Lizenz
+
+> **Wichtig:** WHODAS 2.0 ist **© World Health Organization 2010** (*Measuring Health and Disability: Manual for WHODAS 2.0*, ISBN 9789241547598).
+
+- WHO gestattet **Klinikerinnen und Klinikern die Reproduktion von WHODAS 2.0 zur Nutzung bei eigenen Patient:innen — kostenfrei und ohne gesonderte Genehmigung**.
+- **Jede andere Nutzung — insbesondere die Einbindung in elektronische Datenerfassungssysteme** — **erfordert eine WHO-Lizenzvereinbarung** über den WHO-Classifications-Lizenzprozess. Diese ist für **nicht-kommerzielle Nutzer kostenlos** und verlangt die Online-Zustimmung zu einer Nutzungsvereinbarung.
+- **Übersetzungen** erfordern zusätzlich die Genehmigung der WHO.
+- Nur die **MII-eigenen FHIR-Inhalte** (Profile, Codes, Scoring-Logik) stehen unter **CC0**; der **WHODAS-2.0-Itemtext bleibt © WHO**.
+
+Diese Bedingungen sind maschinenlesbar im `copyright`-Element der Questionnaire- und CodeSystem-Ressourcen hinterlegt.
+
+### Referenzen
+
+- World Health Organization. *Measuring Health and Disability: Manual for WHO Disability Assessment Schedule (WHODAS 2.0)*. Genf: WHO; 2010. ISBN 9789241547598.
+- Kirchberger I, et al. Validation of the WHODAS 2.0 in a population-based sample (MONICA/KORA). *Population Health Metrics* 2014;12:27.
+- Saltychev M, et al. Psychometric properties of the WHODAS 2.0 — systematic review. PMID 31335215.

--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/WHODAS-2.0/toc.yaml
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/WHODAS-2.0/toc.yaml
@@ -1,0 +1,2 @@
+- name: Index
+  filename: Index.page.md

--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/toc.yaml
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/PRO-Bibliothek/toc.yaml
@@ -2,6 +2,8 @@
   filename: Index.page.md
 - name: PHQ-9
   filename: PHQ-9
+- name: PHQ-15
+  filename: PHQ-15
 - name: EQ-5D-5L
   filename: EQ-5D-5L
 - name: EORTC QLQ-C30
@@ -14,6 +16,8 @@
   filename: PROMIS
 - name: DASS-21
   filename: DASS-21
+- name: WHODAS 2.0 (12-Item)
+  filename: WHODAS-2.0
 - name: BDI-II
   filename: BDI-II
 - name: Minimal Reference Questionnaires

--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/Release-Notes.page.md
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/Release-Notes.page.md
@@ -5,6 +5,31 @@ topic: Release-Notes
 
 Diese Seite dokumentiert die Änderungen zwischen den Versionen des MII PRO-Moduls.
 
+**Version: 2026.5.0**
+
+Datum: 2026-07-07 (in Vorbereitung)
+
+Minor-Release: zwei neue Instrumente (**WHODAS 2.0 12-Item** und **PHQ-15**), Aufbau einer gemeinsamen **PHQ-D-Itembank** (PHQ-9/PHQ-15), einheitliche **MII-Score-Codierung** über alle Score-ObsDefs und eine **CI-Verbesserung** (ValueSet-Expansion), die die answerValueSet-Antwortvalidierung dauerhaft korrigiert.
+
+## Neue Instrumente
+
+- Added: **WHODAS 2.0 12-Item (Selbstauskunft)** — WHO Disability Assessment Schedule 2.0, 12 Items über 6 ICF-Domänen, 30-Tage-Recall, 5-stufige Skala (0–4). Englisch primär mit deutschen Translations (validierte PCOR-MII-Wortlaute). Antworten via `answerValueSet` (`mii-vs-pro-whodas-12-answer-list`) mit ordinalValue-Gewichten auf den CodeSystem-Konzepten. **Einschränkungsscore** `mii-obsdef-pro-score-whodas12-simple-sum` (0–48, SNOMED `715823002`, MII-Katalog `whodas12-simple-sum`, höher = mehr Beeinträchtigung). Inkl. Beispiel-QuestionnaireResponse + Score-Observation und IG-Seite.
+  - **Lizenz:** WHODAS 2.0 © WHO 2010. Die Bedingungen sind maschinenlesbar als `copyright` auf Questionnaire und CodeSystem hinterlegt: kostenfreie Kliniker-Eigennutzung; elektronische/Datenerfassungs-Nutzung erfordert eine (für nicht-kommerzielle Nutzung kostenlose) WHO-Nutzungsvereinbarung; Übersetzungen erfordern WHO-Genehmigung; MII-FHIR-Inhalte CC0, WHODAS-Itemtext © WHO.
+- Added: **PHQ-15** (Gesundheitsfragebogen für Patienten, somatische Symptomlast, PHQ-D) — 15 Items, 4-Wochen-Recall, 3-stufige Skala (0–2). Englisch primär mit deutschen Translations (PHQ-D, Löwe et al. 2002). Antworten via `answerValueSet` mit ordinalValue-Gewichten. Score `mii-obsdef-pro-score-phq-15` (0–30, LOINC `70273-8`) inkl. **Schweregrad-Kategorien** (Kroenke et al. 2002: 0–4 / 5–9 / 10–14 / 15–30) als `qualifiedInterval`-Reference-Ranges. Inkl. IG-Seite. Lizenz: frei verfügbar (public domain), PHQ-D.
+
+## Architektur: PHQ-D-Itembank
+
+- Changed: **PHQ-9 und PHQ-15 nutzen ein gemeinsames PHQ-D-Block-LinkId-Schema** (`phq-phq…`). Die in beiden Instrumenten enthaltenen Items (Schlaf `phq-phq2c`, Müdigkeit `phq-phq2d`) teilen sich denselben linkId — Grundlage für item-basiertes Scoring über Instrumente hinweg.
+- Changed: PHQ-15 auf `answerValueSet` + CodeSystem-`ordinalValue` (EN-first) umgestellt; `copyright`/Lizenz-Status auf PHQ-Ressourcen explizit gesetzt.
+
+## Scoring & Terminologie
+
+- Changed: **MII-Katalog-Code (`code.coding[mii]`) auf allen Score-ObservationDefinitions** ergänzt (PROMIS-29 ×8, PROMIS Cognitive Function SF4a, Depression-T-Score, BDI-II, PHQ-9, PHQ-15) — zusätzlich zu LOINC/SNOMED, einheitlich über den MII-Score-Catalogue abfragbar (zuvor bereits EQ-5D/EORTC/DASS-21/PRO-CTCAE).
+
+## Technische Verbesserungen
+
+- Changed: **CI** — `expand-valuesets.js` läuft jetzt nach SUSHI im IG-Build (`ig-publisher.yml`) und schreibt `vs.expansion` aus lokalen CodeSystems. Dadurch kann der Validator die MII-kontrollierten `answerValueSet`-Antwortskalen auflösen; die zuvor gemeldeten „Wert nicht in den angegebenen Optionen"-Findings auf Beispiel-QuestionnaireResponses entfallen (PHQ-15, WHODAS und künftige answerValueSet-Instrumente).
+
 **Version: 2026.4.1**
 
 Datum: 2026-06-15 (released, Tag `v2026.4.1`)


### PR DESCRIPTION
## Was
Ergänzt die **Simplifier-Guide-Seiten** (`implementation-guides/MII-PRO-v2026-DE/…/PRO-Bibliothek/`) für **PHQ-15** und **WHODAS 2.0** — diese fehlten dort (nur `input/pagecontent/` war für den IG-Publisher-IG gepflegt).

- `PHQ-15/Index.page.md` + `toc.yaml`
- `WHODAS-2.0/Index.page.md` + `toc.yaml` (inkl. korrekter WHO-Lizenzbedingungen)
- `PRO-Bibliothek/toc.yaml`: beide registriert (PHQ-15 nach PHQ-9, WHODAS nach DASS-21)

Format wie bestehende Instrumente (Frontmatter `topic`, `<tabs>` mit ISIK-Vorschau + `{{tree/json/xml}}`-Makros).

## Hinweis
Die `{{tree/json/xml}}`- und Vorschau-Makros lösen erst auf, wenn **2026.5.0 nach Simplifier publiziert** ist (WHODAS/PHQ-15 sind erst in 2026.5.0). Canonicals sind stabil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)