### PR TITLE
chore(skills): author-pro-questionnaire + render-questionnaire importieren

### DIFF
--- a/.claude/skills/author-pro-questionnaire/SKILL.md
+++ b/.claude/skills/author-pro-questionnaire/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: author-pro-questionnaire
+description: "Author a new PRO instrument (FHIR Questionnaire + score ObservationDefinition + example) in the MII PRO module, following the repo's settled conventions: naming, canonical item-bank linkIds, answerValueSet + ordinalValue-on-CodeSystem answer modelling, EN-primary + DE-translation, scoring (FHIRPath .ordinal() vs CQL), licensing tiers, and subset/derivedFrom for abbreviated instruments. Use when adding/refactoring a questionnaire instrument (PHQ, GAD, WHODAS, PROMIS, EORTC, etc.). Triggers: 'add a questionnaire', 'implement instrument X', 'build a PRO questionnaire', 'how do we model the answers/scoring/items'."
+---
+
+# author-pro-questionnaire
+
+Playbook + conventions for building a PRO **Questionnaire** resource (plus its score
+**ObservationDefinition** and an example **QuestionnaireResponse**) in this IG.
+
+**Canonical templates to copy from:** `input/fsh/definitions/phq-15/` and `phq-9/` (depression),
+`whodas/` (licensed instrument, derived-from), `promis-29/` (multi-domain + variable scoring).
+
+---
+
+## 1. Files & naming
+
+Folder: `input/fsh/definitions/<instrument>/`. Files (MII prefixes):
+- `mii-qst-pro-<instrument>.fsh` — the Questionnaire (`Instance`, `InstanceOf: mii-pr-pro-questionnaire`, `Usage: #definition`).
+- `mii-cs-pro-<instrument>-answers.fsh` + `mii-vs-pro-<instrument>-answers.fsh` — answer scale (see §4).
+- `mii-obsdef-pro-score-<instrument>.fsh` — score ObservationDefinition (see §5).
+- `mii-exa-pro-<instrument>-response.fsh` — example (see §7).
+
+Register: add the questionnaire code to `input/fsh/profiles/mii-cs-pro-questionnaire-catalogue.fsh`
+(`* #<code> "..."`), the score code to `mii-cs-pro-score-catalogue.fsh`, and aliases to `input/fsh/aliases.fsh`.
+
+**Resource IDs are stable** (canonical URLs) — never rename a published resource id; change linkIds instead.
+
+## 2. Versioning (always)
+`* insert Version` (Questionnaire) · `* insert MetaProfile(<canonical>)` (instances) ·
+`* insert PR_CS_VS_Version` (CS/VS/profiles) · `* insert ObsDefVersion` (ObservationDefinition).
+Never hardcode version strings. (RuleSets in `input/fsh/rulesets/version.fsh`.)
+
+## 3. Language — EN-primary + DE-translation (repo convention)
+`* language = #en`. Each item: `* item[x].text = "<English>"` + the `$hl7-translation` extension
+carrying `#de` + the validated German. Answer CodeSystem: English `display` + German `designation` (#de).
+(Mirror PHQ-9/PROMIS-29.) The validated German comes from the PCOR-MII Item Level Dictionary /
+official translation (e.g. PHQ-D for the PHQ family).
+
+## 4. Answers — answerValueSet + ordinalValue on the CodeSystem
+Define one MII answer CodeSystem with an `ordinalValue` **property** per concept (the scoring weight),
+and a ValueSet binding it; items reference it via `answerValueSet`:
+```fsh
+CodeSystem: MII_CS_PRO_<X>_Answers
+* ^property[+].code = #ordinalValue
+* ^property[=].uri = "http://hl7.org/fhir/StructureDefinition/ordinalValue"
+* ^property[=].type = #decimal
+* #not-bothered "Not bothered at all"
+  * ^designation[+].language = #de
+  * ^designation[=].value = "Nicht beeinträchtigt"
+  * ^property[+].code = #ordinalValue
+  * ^property[=].valueDecimal = 0
+... (repeat per option)
+// Questionnaire item:
+* item[x].answerValueSet = Canonical(MII_VS_PRO_<X>_Answers)
+```
+A shared scale (same options for all items) → ONE CS/VS for the whole instrument.
+
+⚠️ **Scoring caveat:** in-form `.ordinal()` resolution from `answerValueSet` is **engine-dependent**
+(many SDC form-fillers read the weight only from inline `answerOption`). For robust scoring use **CQL**
+(resolves CodeSystem weights reliably; see `cql-development` skill, 2026+ roadmap). If you need
+FHIRPath in-form live scoring, fall back to inline `answerOption` + `ordinalValue`. Document the choice.
+
+## 5. Scoring
+Root FHIR `variable` + a readOnly score item:
+```fsh
+* extension[+].url = "http://hl7.org/fhir/StructureDefinition/variable"
+* extension[=].valueExpression.name = "<x>Sum"
+* extension[=].valueExpression.language = #text/fhirpath
+* extension[=].valueExpression.expression = "%resource.item.where(linkId.matches('<regex over the scored linkIds>')).answer.value.ordinal().sum()"
+* item[score].type = #decimal     // readOnly = true
+* item[score].extension[calculatedExpression]...expression = "%<x>Sum"
+* item[score].extension[observationExtract].valueBoolean = true
+* item[score].extension[questionnaire-unit].valueCoding = $UCUM#{score}
+```
+For multiple/derived scores (T-scores etc.) define variables once and reference them (avoids circular deps).
+`ObservationDefinition`: `insert ObsDefVersion` + MetaProfile, `code` = LOINC + MII score-catalogue code,
+`permittedDataType = #Quantity`, `quantitativeDetails.unit = $UCUM#{score}`, `qualifiedInterval.range` (e.g. 0–N),
+plus the ScoreHealthCorrelation extension (increase/decrease).
+
+## 6. linkId namespace — canonical item ids (item bank)
+linkId = **canonical item identity**, shared across instruments so the SAME question has the SAME linkId.
+- **PHQ family** uses the PHQ-D block namespace: `phq-phq1{a..m}` (somatic/PHQ-15), `phq-phq2{a..i}`
+  (depression/PHQ-9), `phq-phq5{a..g}` (GAD). Shared items (sleep `phq-phq2c`, fatigue `phq-phq2d`)
+  carry the **same linkId** in PHQ-9 and PHQ-15. (Instrument-specific code/recall is allowed on the same
+  shared linkId.) Non-symptom items (functional, derived scores) keep instrument-specific ids.
+- **Other instruments:** `<instrument>-<itemid>` (e.g. `whodas-whodas12-q01`, `promis-pfa11`).
+The `item.code` carries the terminology (LOINC where it exists; else MII item codes).
+
+## 7. Example
+`mii-exa-pro-<instrument>-response` (`InstanceOf: QuestionnaireResponse` or the QR profile, `Usage: #example`):
+answer all items with values giving an **easy-to-verify sum** (state it in a comment), set `status`,
+`questionnaire`, `authored` (required by MII_PR_PRO_QuestionnaireResponse). Optionally a score Observation example.
+
+## 8. Licensing tiers — drive the capabilities
+| Tier | License | Modelling |
+|---|---|---|
+| **A — open** | public/free (PHQ, GAD, PROMIS) | full items; displayable/collectable = true |
+| **B — licensed/permission** | WHO/WHODAS (free non-commercial **with permission**) | full items, `experimental = true`, `copyright` notice, **"NOT FOR PUBLICATION until licensing confirmed"** header; review-only |
+| **C — commercial/registration** | BDI-II, EORTC, FACT, registration-required | **metadata-only** (no item text), displayable/collectable = false; document the licensing process |
+Classify the license BEFORE setting capabilities. (See the DIZ/PCOR-MII license table.)
+
+## 9. Abbreviated / subset instruments (derivedFrom)
+When an instrument uses only a subset of a larger one (e.g. a 2-item PROMIS Global Health):
+- model a **separate Questionnaire** with `* derivedFrom = "<canonical of the full instrument>"`, containing
+  only the used items, with `required = true`. Questionnaire-based validation then enforces the subset
+  (rejects foreign items + requires the chosen items present) — **no QR profile needed** in the normal case.
+- A `closed`-slicing QR profile is only a **fallback** for pipelines that validate against the profile WITHOUT
+  the questionnaire; use `open` slicing + required slices (never bother with `closed` — the questionnaire
+  already rejects foreign items). Subset questionnaires belong in the **PCOR-MII repo** (use-case layer),
+  not the KDS module (canonical instruments).
+
+## 10. Validate & review
+- `sushi . --snapshot` → must be **0 errors** (snapshots needed for profile/QR validation).
+- Review the form with the **`render-questionnaire`** skill (dependency-free HTML, shows options + weights + DE).
+- Optional deep validation: HL7 `validator_cli.jar` (QR vs questionnaire/profile) — needs snapshots.
+- Commit only the instrument's FSH + its generated JSON; never commit SUSHI snapshot churn (3.19 vs 3.20).

--- a/.claude/skills/render-questionnaire/SKILL.md
+++ b/.claude/skills/render-questionnaire/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: render-questionnaire
+description: "Render a generated FHIR Questionnaire JSON as a dependency-free, offline HTML preview for review. Resolves answerValueSet via the CodeSystems in fsh-generated, shows each item with its answer options, the ordinalValue scoring weights (badges), and German translations (translation extension). Use when you want to SEE/review a questionnaire form without the IG Publisher (no Jekyll) or LHC-Forms (no CDN) — e.g. reviewing PHQ-9/PHQ-15/WHODAS/PROMIS questionnaires. Triggers: 'render the questionnaire', 'preview the form', 'show me the questionnaire to review'."
+---
+
+# render-questionnaire
+
+Produces a self-contained HTML preview of a FHIR R4 Questionnaire so it can be reviewed
+visually, **without** external dependencies (no IG Publisher/Jekyll, no LHC-Forms CDN).
+
+## What it shows
+- Groups → sections, `display` items → stems, `choice` items → questions with their answer options.
+- **answerValueSet is resolved** against the CodeSystems found in the same `fsh-generated/resources`
+  folder, so options appear even when not inline.
+- **ordinalValue weight badges** per option (read from the answerOption extension OR the
+  CodeSystem concept `ordinalValue`/`itemWeight` property) — a missing weight is flagged red.
+- **German translations** (the `hl7-translation` extension) shown under each EN-primary text.
+
+## Usage
+```bash
+python3 .claude/skills/render-questionnaire/render_questionnaire.py \
+  fsh-generated/resources/Questionnaire-mii-qst-pro-phq-15.json \
+  --title "PHQ-15 (Review)" --open
+```
+- First arg: path (or glob) to the generated Questionnaire JSON.
+- `--out <file>`: output HTML path (default: /tmp/<id>-preview.html).
+- `--title "..."`: heading. `--note "..."`: yellow note box (e.g. licensing).
+- `--open`: open the HTML in the default browser (macOS `open`).
+
+Terminology (CodeSystem/ValueSet) is auto-loaded from the Questionnaire JSON's directory.
+
+## Notes
+- This is a **review** tool, not a form filler — it does not evaluate `calculatedExpression`
+  (no live scoring). Weight badges reflect the declared ordinalValue, so reviewers can check
+  the scoring weights without a runtime engine.
+- For interactive filling/live scoring use the project's actual SDC renderer (gefyra/ISiK) or
+  the IG Publisher build.

--- a/.claude/skills/render-questionnaire/render_questionnaire.py
+++ b/.claude/skills/render-questionnaire/render_questionnaire.py
@@ -1,0 +1,112 @@
+import json, glob, html, os
+def esc(s): return html.escape(str(s)) if s is not None else ""
+def load_terminology(resdir):
+    cs={}  # system-url -> {code: (display, ordinal)}
+    vs={}  # vs-url -> [(system,code)]
+    for f in glob.glob(os.path.join(resdir,"*.json")):
+        try: d=json.load(open(f,encoding="utf-8"))
+        except: continue
+        rt=d.get("resourceType")
+        if rt=="CodeSystem":
+            url=d.get("url"); m={}
+            propmap={}
+            for c in d.get("concept",[]):
+                ordv=None
+                for p in c.get("property",[]):
+                    if p.get("code") in ("ordinalValue","itemWeight"): ordv=p.get("valueDecimal")
+                m[c.get("code")]=(c.get("display"),ordv)
+            cs[url]=m
+        elif rt=="ValueSet":
+            url=d.get("url"); incs=[]
+            for inc in d.get("compose",{}).get("include",[]):
+                sysu=inc.get("system")
+                if inc.get("concept"):
+                    for c in inc["concept"]: incs.append((sysu,c.get("code")))
+                else: incs.append((sysu,None))  # all from system
+            vs[url]=incs
+    return cs,vs
+def de_translation(el):
+    for e in (el.get("_text",{}) or {}).get("extension",[]) if isinstance(el.get("_text"),dict) else []:
+        pass
+    return None
+def render(q, cs, vs):
+    out=[]
+    def opts_for_vs(vsurl):
+        rows=[]
+        for (sysu,code) in vs.get(vsurl,[]):
+            concepts=cs.get(sysu,{})
+            items=[(code,)+concepts[code]] if code and code in concepts else [(c,)+v for c,v in concepts.items()]
+            for code2,disp,ordv in items:
+                badge=f"<span class=w>{ordv}</span>" if ordv is not None else "<span class=w style=background:#fdd>kein Gewicht!</span>"
+                rows.append(f"<label><input type=radio disabled> {esc(disp)} {badge}</label>")
+        return "".join(rows)
+    def walk(items):
+        for it in items or []:
+            t=it.get("type"); txt=it.get("text",""); pre=it.get("prefix","")
+            # de translation
+            de=""
+            ext=(it.get("_text") or {}).get("extension",[]) if isinstance(it.get("_text"),dict) else []
+            for e in ext:
+                if e.get("url","").endswith("translation"):
+                    lang=cont=None
+                    for sub in e.get("extension",[]):
+                        if sub.get("url")=="lang": lang=sub.get("valueCode")
+                        if sub.get("url")=="content": cont=sub.get("valueString")
+                    if lang=="de" and cont: de=cont
+            detag=f"<div class=de>DE: {esc(de)}</div>" if de else ""
+            if t=="group":
+                out.append(f"<fieldset><legend>{esc(txt)}</legend>{detag}"); walk(it.get("item",[])); out.append("</fieldset>")
+            elif t=="display":
+                out.append(f"<p class=stem>{esc(txt)}</p>{detag}")
+            elif t in ("choice","open-choice"):
+                if it.get("answerValueSet"): o=opts_for_vs(it["answerValueSet"])
+                else:
+                    o=""
+                    for opt in it.get("answerOption",[]):
+                        vc=opt.get("valueCoding",{}); ordv=None
+                        for e in opt.get("extension",[]):
+                            if "ordinal" in e.get("url",""): ordv=e.get("valueDecimal")
+                        o+=f"<label><input type=radio disabled> {esc(vc.get('display'))} <span class=w>{ordv}</span></label>"
+                out.append(f"<div class=q><div class=qt>{esc(pre)+'. ' if pre else ''}{esc(txt)}</div>{detag}<div class=opts>{o}</div></div>")
+            else:
+                ro=" (readOnly/berechnet)" if it.get("readOnly") else ""
+                out.append(f"<div class=q score><div class=qt>{esc(pre)+': ' if pre else ''}{esc(txt)} <span class=code>[{esc(t)}{ro}]</span></div>{detag}</div>")
+    walk(q.get("item",[]))
+    return "\n".join(out)
+def build(qglob, out, title, note):
+    f=glob.glob(qglob); 
+    if not f: print("NICHT gefunden"); return
+    resdir=os.path.dirname(f[0]); cs,vs=load_terminology(resdir)
+    q=json.load(open(f[0],encoding="utf-8")); body=render(q,cs,vs)
+    doc=f"""<!doctype html><html lang=de><head><meta charset=utf-8><title>{esc(title)}</title>
+<style>body{{font-family:system-ui,sans-serif;max-width:840px;margin:1.5rem auto;padding:0 1rem;color:#222}}
+.meta{{color:#666;font-size:.85rem}} .note{{background:#fff8e1;border:1px solid #f0d000;padding:.6rem .9rem;border-radius:6px;font-size:.85rem;margin:.6rem 0 1.2rem}}
+.stem{{font-style:italic;color:#456}} .de{{color:#888;font-size:.8rem;margin:.1rem 0 .2rem}}
+.q{{margin:.5rem 0;padding:.4rem .6rem;border-left:3px solid #e3e6ef}} .q.score{{border-left-color:#79c;background:#f4f8ff}}
+.qt{{font-weight:500}} .opts{{margin-top:.25rem;display:flex;flex-wrap:wrap;gap:.35rem 1rem}} .opts label{{font-size:.9rem}}
+.w{{background:#eef;border:1px solid #ccd;border-radius:10px;font-size:.7rem;padding:0 .35rem;color:#447}} .code{{font-family:monospace;font-size:.7rem;color:#999}}</style></head><body>
+<h2>{esc(title)}</h2><div class=meta>{esc(q.get('title'))} · primary lang={esc(q.get('language'))} · {len(q.get('item',[]))} Items</div>
+<div class=note>{note}</div>{body}
+<p class=meta>Eigen-Render: answerValueSet aufgelöst über CodeSystem; Badge = ordinalValue-Gewicht (aus CS-Konzept). DE = Übersetzungs-Extension.</p></body></html>"""
+    open(out,"w",encoding="utf-8").write(doc); print("OK:",out)
+
+# ---- CLI ----
+if __name__ == "__main__":
+    import argparse, os, subprocess, json as _json, glob as _glob
+    ap = argparse.ArgumentParser(description="Render a FHIR Questionnaire JSON as dependency-free HTML preview")
+    ap.add_argument("questionnaire", help="path or glob to generated Questionnaire-*.json")
+    ap.add_argument("--out", default=None, help="output HTML path")
+    ap.add_argument("--title", default=None)
+    ap.add_argument("--note", default="")
+    ap.add_argument("--open", action="store_true", help="open in default browser (macOS)")
+    a = ap.parse_args()
+    fs = _glob.glob(a.questionnaire)
+    if not fs:
+        raise SystemExit(f"Not found: {a.questionnaire}")
+    qf = fs[0]
+    qid = _json.load(open(qf, encoding="utf-8")).get("id", "questionnaire")
+    out = a.out or f"/tmp/{qid}-preview.html"
+    title = a.title or qid
+    build(qf, out, title, a.note)
+    if a.open:
+        subprocess.run(["open", out])


### PR DESCRIPTION
Versioniert zwei proms-spezifische Skills, die bisher nur untracked im Working-Tree lagen:

- **author-pro-questionnaire** — Playbook/Konventionen zum Aufbau eines PRO-Questionnaire (+ Score-ObsDef + Beispiel-QR).
- **render-questionnaire** — dependency-freie HTML-Vorschau eines generierten Questionnaire (löst answerValueSet auf, ordinalValue-Badges + DE).

Konsistent mit den bereits getrackten Skills in `.claude/skills/`. Reine `.claude/`-Dateien, keine FHIR-Änderung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)