### PR TITLE
feat(scores): dedizierte Observation-Profile für PHQ-9, PHQ-15, WHODAS-12

### DIFF
--- a/fsh-generated/resources/Bundle-mii-exa-pro-phq-9-bundle.json
+++ b/fsh-generated/resources/Bundle-mii-exa-pro-phq-9-bundle.json
@@ -1975,20 +1975,15 @@
         "id": "mii-exa-pro-phq-9-observation",
         "meta": {
           "profile": [
-            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
+            "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-9|2026.5.0"
           ]
         },
         "valueQuantity": {
-          "value": 27,
-          "code": "{score}",
           "unit": "{score}",
-          "system": "http://unitsofmeasure.org"
+          "system": "http://unitsofmeasure.org",
+          "code": "{score}",
+          "value": 27
         },
-        "status": "final",
-        "subject": {
-          "reference": "Patient/mii-exa-pro-patient"
-        },
-        "effectiveDateTime": "2023-10-01T12:00:00Z",
         "code": {
           "coding": [
             {
@@ -1997,7 +1992,12 @@
               "display": "Patient Health Questionnaire 9 item (PHQ-9) total score [Reported]"
             }
           ]
-        }
+        },
+        "status": "final",
+        "subject": {
+          "reference": "Patient/mii-exa-pro-patient"
+        },
+        "effectiveDateTime": "2023-10-01T12:00:00Z"
       }
     },
     {

--- a/fsh-generated/resources/ImplementationGuide-mii-ig-pro.json
+++ b/fsh-generated/resources/ImplementationGuide-mii-ig-pro.json
@@ -828,6 +828,30 @@
       },
       {
         "reference": {
+          "reference": "StructureDefinition/mii-pr-pro-observation-phq-15"
+        },
+        "name": "MII PR PRO Observation PHQ-15",
+        "description": "Profile for Patient Health Questionnaire-15 (PHQ-15) total somatic symptom severity score Observations (0-30; higher scores indicate greater somatic symptom burden).",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "StructureDefinition/mii-pr-pro-observation-phq-9"
+        },
+        "name": "MII PR PRO Observation PHQ-9",
+        "description": "Profile for Patient Health Questionnaire-9 (PHQ-9) total score Observations (0-27; higher scores indicate more severe depression).",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
+          "reference": "StructureDefinition/mii-pr-pro-observation-whodas12"
+        },
+        "name": "MII PR PRO Observation WHODAS 2.0 12-Item",
+        "description": "Profile for WHODAS 2.0 12-item simple sum (disability) score Observations (0-48; higher scores indicate greater disability). No suitable LOINC code exists; SNOMED CT and the MII score catalogue are used.",
+        "exampleBoolean": false
+      },
+      {
+        "reference": {
           "reference": "StructureDefinition/mii-pr-pro-promis-cognitive-function-sf4a-raw-score"
         },
         "name": "MII PR PRO PROMIS Cognitive Function SF 4a Raw Score",
@@ -1406,14 +1430,14 @@
           "reference": "Observation/mii-exa-pro-phq-15-observation"
         },
         "name": "PHQ-15 Score Observation Example",
-        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance"
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-15"
       },
       {
         "reference": {
           "reference": "Observation/mii-exa-pro-phq-9-observation"
         },
         "name": "PHQ-9 Observation Example",
-        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance"
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-9"
       },
       {
         "reference": {
@@ -1475,7 +1499,7 @@
         },
         "name": "WHODAS 2.0 12-Item Simple Sum Score Observation",
         "description": "WHODAS-12 simple sum score observation (all items 'Moderate': 12 × 2 = 24).",
-        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance"
+        "exampleCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-whodas12"
       }
     ],
     "page": {

--- a/fsh-generated/resources/Observation-mii-exa-pro-phq-15-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-phq-15-observation.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-phq-15-observation",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-15|2026.5.0"
     ]
   },
   "derivedFrom": [
@@ -12,16 +12,11 @@
     }
   ],
   "valueQuantity": {
-    "value": 15,
-    "code": "{score}",
     "unit": "{score}",
-    "system": "http://unitsofmeasure.org"
+    "system": "http://unitsofmeasure.org",
+    "code": "{score}",
+    "value": 15
   },
-  "status": "final",
-  "subject": {
-    "reference": "Patient/mii-exa-pro-patient"
-  },
-  "effectiveDateTime": "2024-03-15T10:00:00Z",
   "code": {
     "coding": [
       {
@@ -30,5 +25,10 @@
         "display": "Patient Health Questionnaire 15 item (PHQ-15) total score [Reported]"
       }
     ]
-  }
+  },
+  "status": "final",
+  "subject": {
+    "reference": "Patient/mii-exa-pro-patient"
+  },
+  "effectiveDateTime": "2024-03-15T10:00:00Z"
 }

--- a/fsh-generated/resources/Observation-mii-exa-pro-phq-9-observation.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-phq-9-observation.json
@@ -3,20 +3,15 @@
   "id": "mii-exa-pro-phq-9-observation",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-9|2026.5.0"
     ]
   },
   "valueQuantity": {
-    "value": 27,
-    "code": "{score}",
     "unit": "{score}",
-    "system": "http://unitsofmeasure.org"
+    "system": "http://unitsofmeasure.org",
+    "code": "{score}",
+    "value": 27
   },
-  "status": "final",
-  "subject": {
-    "reference": "Patient/mii-exa-pro-patient"
-  },
-  "effectiveDateTime": "2023-10-01T12:00:00Z",
   "code": {
     "coding": [
       {
@@ -25,5 +20,10 @@
         "display": "Patient Health Questionnaire 9 item (PHQ-9) total score [Reported]"
       }
     ]
-  }
+  },
+  "status": "final",
+  "subject": {
+    "reference": "Patient/mii-exa-pro-patient"
+  },
+  "effectiveDateTime": "2023-10-01T12:00:00Z"
 }

--- a/fsh-generated/resources/Observation-mii-exa-pro-whodas12-score-simple-sum.json
+++ b/fsh-generated/resources/Observation-mii-exa-pro-whodas12-score-simple-sum.json
@@ -3,7 +3,7 @@
   "id": "mii-exa-pro-whodas12-score-simple-sum",
   "meta": {
     "profile": [
-      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance|2026.5.0"
+      "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-whodas12|2026.5.0"
     ]
   },
   "category": [
@@ -35,10 +35,10 @@
     "reference": "Patient/mii-exa-pro-patient"
   },
   "valueQuantity": {
-    "value": 24,
     "unit": "{score}",
     "system": "http://unitsofmeasure.org",
-    "code": "{score}"
+    "code": "{score}",
+    "value": 24
   },
   "derivedFrom": [
     {

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-phq-15.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-phq-15.json
@@ -1,0 +1,88 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mii-pr-pro-observation-phq-15",
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-15",
+  "version": "2026.5.0",
+  "name": "MII_PR_PRO_Observation_PHQ_15",
+  "title": "MII PR PRO Observation PHQ-15",
+  "status": "active",
+  "experimental": true,
+  "description": "Profile for Patient Health Questionnaire-15 (PHQ-15) total somatic symptom severity score Observations (0-30; higher scores indicate greater somatic symptom burden).",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.extension:instantiatesCanonical",
+        "path": "Observation.extension",
+        "sliceName": "instantiatesCanonical"
+      },
+      {
+        "id": "Observation.extension:instantiatesCanonical.value[x]",
+        "path": "Observation.extension.value[x]",
+        "patternCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ObservationDefinition/mii-obsdef-pro-score-phq-15"
+      },
+      {
+        "id": "Observation.code",
+        "path": "Observation.code",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "70273-8",
+              "system": "http://loinc.org",
+              "display": "Patient Health Questionnaire 15 item (PHQ-15) total score [Reported]"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.value[x]",
+        "path": "Observation.value[x]",
+        "type": [
+          {
+            "code": "Quantity"
+          }
+        ]
+      },
+      {
+        "id": "Observation.value[x].value",
+        "path": "Observation.value[x].value",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.value[x].unit",
+        "path": "Observation.value[x].unit",
+        "fixedString": "{score}"
+      },
+      {
+        "id": "Observation.value[x].system",
+        "path": "Observation.value[x].system",
+        "fixedUri": "http://unitsofmeasure.org"
+      },
+      {
+        "id": "Observation.value[x].code",
+        "path": "Observation.value[x].code",
+        "fixedCode": "{score}"
+      },
+      {
+        "id": "Observation.method.coding",
+        "path": "Observation.method.coding",
+        "patternCoding": {
+          "code": "69728-4",
+          "system": "http://loinc.org",
+          "display": "Patient Health Questionnaire 15 item (PHQ-15) [Reported]"
+        }
+      },
+      {
+        "id": "Observation.method.text",
+        "path": "Observation.method.text",
+        "patternString": "Patient Health Questionnaire-15 (PHQ-15)"
+      }
+    ]
+  }
+}

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-phq-9.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-phq-9.json
@@ -1,0 +1,88 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mii-pr-pro-observation-phq-9",
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-9",
+  "version": "2026.5.0",
+  "name": "MII_PR_PRO_Observation_PHQ_9",
+  "title": "MII PR PRO Observation PHQ-9",
+  "status": "active",
+  "experimental": true,
+  "description": "Profile for Patient Health Questionnaire-9 (PHQ-9) total score Observations (0-27; higher scores indicate more severe depression).",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.extension:instantiatesCanonical",
+        "path": "Observation.extension",
+        "sliceName": "instantiatesCanonical"
+      },
+      {
+        "id": "Observation.extension:instantiatesCanonical.value[x]",
+        "path": "Observation.extension.value[x]",
+        "patternCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ObservationDefinition/mii-obsdef-pro-score-phq-9"
+      },
+      {
+        "id": "Observation.code",
+        "path": "Observation.code",
+        "patternCodeableConcept": {
+          "coding": [
+            {
+              "code": "44261-6",
+              "system": "http://loinc.org",
+              "display": "Patient Health Questionnaire 9 item (PHQ-9) total score [Reported]"
+            }
+          ]
+        }
+      },
+      {
+        "id": "Observation.value[x]",
+        "path": "Observation.value[x]",
+        "type": [
+          {
+            "code": "Quantity"
+          }
+        ]
+      },
+      {
+        "id": "Observation.value[x].value",
+        "path": "Observation.value[x].value",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.value[x].unit",
+        "path": "Observation.value[x].unit",
+        "fixedString": "{score}"
+      },
+      {
+        "id": "Observation.value[x].system",
+        "path": "Observation.value[x].system",
+        "fixedUri": "http://unitsofmeasure.org"
+      },
+      {
+        "id": "Observation.value[x].code",
+        "path": "Observation.value[x].code",
+        "fixedCode": "{score}"
+      },
+      {
+        "id": "Observation.method.coding",
+        "path": "Observation.method.coding",
+        "patternCoding": {
+          "code": "44249-1",
+          "system": "http://loinc.org",
+          "display": "PHQ-9 quick depression assessment panel [Reported.PHQ]"
+        }
+      },
+      {
+        "id": "Observation.method.text",
+        "path": "Observation.method.text",
+        "patternString": "Patient Health Questionnaire-9 (PHQ-9)"
+      }
+    ]
+  }
+}

--- a/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-whodas12.json
+++ b/fsh-generated/resources/StructureDefinition-mii-pr-pro-observation-whodas12.json
@@ -1,0 +1,72 @@
+{
+  "resourceType": "StructureDefinition",
+  "id": "mii-pr-pro-observation-whodas12",
+  "url": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-whodas12",
+  "version": "2026.5.0",
+  "name": "MII_PR_PRO_Observation_WHODAS_12",
+  "title": "MII PR PRO Observation WHODAS 2.0 12-Item",
+  "status": "active",
+  "experimental": true,
+  "description": "Profile for WHODAS 2.0 12-item simple sum (disability) score Observations (0-48; higher scores indicate greater disability). No suitable LOINC code exists; SNOMED CT and the MII score catalogue are used.",
+  "fhirVersion": "4.0.1",
+  "kind": "resource",
+  "abstract": false,
+  "type": "Observation",
+  "baseDefinition": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance",
+  "derivation": "constraint",
+  "differential": {
+    "element": [
+      {
+        "id": "Observation.extension:instantiatesCanonical",
+        "path": "Observation.extension",
+        "sliceName": "instantiatesCanonical"
+      },
+      {
+        "id": "Observation.extension:instantiatesCanonical.value[x]",
+        "path": "Observation.extension.value[x]",
+        "patternCanonical": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ObservationDefinition/mii-obsdef-pro-score-whodas12-simple-sum"
+      },
+      {
+        "id": "Observation.code.coding",
+        "path": "Observation.code.coding",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.value[x]",
+        "path": "Observation.value[x]",
+        "type": [
+          {
+            "code": "Quantity"
+          }
+        ]
+      },
+      {
+        "id": "Observation.value[x].value",
+        "path": "Observation.value[x].value",
+        "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "Observation.value[x].unit",
+        "path": "Observation.value[x].unit",
+        "fixedString": "{score}"
+      },
+      {
+        "id": "Observation.value[x].system",
+        "path": "Observation.value[x].system",
+        "fixedUri": "http://unitsofmeasure.org"
+      },
+      {
+        "id": "Observation.value[x].code",
+        "path": "Observation.value[x].code",
+        "fixedCode": "{score}"
+      },
+      {
+        "id": "Observation.method.text",
+        "path": "Observation.method.text",
+        "patternString": "WHODAS 2.0 12-item simple sum scoring (0-48)"
+      }
+    ]
+  }
+}

--- a/input/fsh/definitions/phq-15/mii-exa-pro-phq-15-response.fsh
+++ b/input/fsh/definitions/phq-15/mii-exa-pro-phq-15-response.fsh
@@ -64,10 +64,10 @@ Title: "PHQ-15 Questionnaire Response Example"
 
 // Score Observation: PHQ-15 total score extracted from QuestionnaireResponse above
 Instance: mii-exa-pro-phq-15-observation
-InstanceOf: MII_PR_PRO_Score_Instance
+InstanceOf: MII_PR_PRO_Observation_PHQ_15
 Usage: #example
 Title: "PHQ-15 Score Observation Example"
-* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance)
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-15)
 * status = #final
 * subject = Reference(Patient/mii-exa-pro-patient)
 * effectiveDateTime = "2024-03-15T10:00:00Z"

--- a/input/fsh/definitions/phq-15/mii-pr-pro-observation-phq-15.fsh
+++ b/input/fsh/definitions/phq-15/mii-pr-pro-observation-phq-15.fsh
@@ -1,0 +1,29 @@
+Profile: MII_PR_PRO_Observation_PHQ_15
+Parent: MII_PR_PRO_Score_Instance
+Id: mii-pr-pro-observation-phq-15
+Title: "MII PR PRO Observation PHQ-15"
+Description: "Profile for Patient Health Questionnaire-15 (PHQ-15) total somatic symptom severity score Observations (0-30; higher scores indicate greater somatic symptom burden)."
+
+* insert PR_CS_VS_Version
+* ^status = #active
+* ^experimental = true
+
+* code = $LNC#70273-8 "Patient Health Questionnaire 15 item (PHQ-15) total score [Reported]"
+* code MS
+
+* value[x] only Quantity
+* valueQuantity MS
+* valueQuantity.value 1..1 MS
+* valueQuantity.unit = "{score}" (exactly)
+* valueQuantity.system = $UCUM (exactly)
+* valueQuantity.code = #{score} (exactly)
+
+* method.coding = $LNC#69728-4 "Patient Health Questionnaire 15 item (PHQ-15) [Reported]"
+* method.text = "Patient Health Questionnaire-15 (PHQ-15)"
+* method MS
+
+// Link to the ObservationDefinition that defines reference ranges (incl. Kroenke severity bands)
+* extension[instantiatesCanonical].valueCanonical = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ObservationDefinition/mii-obsdef-pro-score-phq-15"
+
+* interpretation MS
+* derivedFrom MS

--- a/input/fsh/definitions/phq-9/mii-pr-pro-observation-phq-9.fsh
+++ b/input/fsh/definitions/phq-9/mii-pr-pro-observation-phq-9.fsh
@@ -1,0 +1,29 @@
+Profile: MII_PR_PRO_Observation_PHQ_9
+Parent: MII_PR_PRO_Score_Instance
+Id: mii-pr-pro-observation-phq-9
+Title: "MII PR PRO Observation PHQ-9"
+Description: "Profile for Patient Health Questionnaire-9 (PHQ-9) total score Observations (0-27; higher scores indicate more severe depression)."
+
+* insert PR_CS_VS_Version
+* ^status = #active
+* ^experimental = true
+
+* code = $LNC#44261-6 "Patient Health Questionnaire 9 item (PHQ-9) total score [Reported]"
+* code MS
+
+* value[x] only Quantity
+* valueQuantity MS
+* valueQuantity.value 1..1 MS
+* valueQuantity.unit = "{score}" (exactly)
+* valueQuantity.system = $UCUM (exactly)
+* valueQuantity.code = #{score} (exactly)
+
+* method.coding = $LNC#44249-1 "PHQ-9 quick depression assessment panel [Reported.PHQ]"
+* method.text = "Patient Health Questionnaire-9 (PHQ-9)"
+* method MS
+
+// Link to the ObservationDefinition that defines reference ranges and measurement details
+* extension[instantiatesCanonical].valueCanonical = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ObservationDefinition/mii-obsdef-pro-score-phq-9"
+
+* interpretation MS
+* derivedFrom MS

--- a/input/fsh/definitions/whodas/mii-pr-pro-observation-whodas12.fsh
+++ b/input/fsh/definitions/whodas/mii-pr-pro-observation-whodas12.fsh
@@ -1,0 +1,31 @@
+Profile: MII_PR_PRO_Observation_WHODAS_12
+Parent: MII_PR_PRO_Score_Instance
+Id: mii-pr-pro-observation-whodas12
+Title: "MII PR PRO Observation WHODAS 2.0 12-Item"
+Description: "Profile for WHODAS 2.0 12-item simple sum (disability) score Observations (0-48; higher scores indicate greater disability). No suitable LOINC code exists; SNOMED CT and the MII score catalogue are used."
+
+* insert PR_CS_VS_Version
+* ^status = #active
+* ^experimental = true
+
+// The concrete code (SNOMED 715823002 + MII score-catalogue whodas12-simple-sum) is
+// carried by the instance and defined authoritatively by the ObservationDefinition;
+// no LOINC code exists for WHODAS.
+* code MS
+* code.coding 1..* MS
+
+* value[x] only Quantity
+* valueQuantity MS
+* valueQuantity.value 1..1 MS
+* valueQuantity.unit = "{score}" (exactly)
+* valueQuantity.system = $UCUM (exactly)
+* valueQuantity.code = #{score} (exactly)
+
+* method.text = "WHODAS 2.0 12-item simple sum scoring (0-48)"
+* method MS
+
+// Link to the ObservationDefinition that defines the measurable range and scoring direction
+* extension[instantiatesCanonical].valueCanonical = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ObservationDefinition/mii-obsdef-pro-score-whodas12-simple-sum"
+
+* interpretation MS
+* derivedFrom MS

--- a/input/fsh/examples/mii-exa-pro-phq-9-observation.fsh
+++ b/input/fsh/examples/mii-exa-pro-phq-9-observation.fsh
@@ -1,9 +1,9 @@
 // Example Observation-based Extraction, see https://build.fhir.org/ig/HL7/sdc/extraction.html#obs-extract
 Instance: mii-exa-pro-phq-9-observation
-InstanceOf: MII_PR_PRO_Score_Instance
+InstanceOf: MII_PR_PRO_Observation_PHQ_9
 Usage: #example
 Title: "PHQ-9 Observation Example"
-* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance)
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-phq-9)
 * status = #final
 // * basedOn = Reference(mii-obsdef-pro-score-phq-9) geht nicht weil Observation.instantiatesCanonical erst in R5 kommt, und die R4 extension kein ObservationDefinition unterstützt, aber dafür Measure
 * subject = Reference(Patient/mii-exa-pro-patient)

--- a/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
+++ b/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
@@ -76,11 +76,11 @@ Usage: #example
 // ============================================================================
 
 Instance: mii-exa-pro-whodas12-score-simple-sum
-InstanceOf: mii-pr-pro-score-instance
+InstanceOf: mii-pr-pro-observation-whodas12
 Title: "WHODAS 2.0 12-Item Simple Sum Score Observation"
 Description: "WHODAS-12 simple sum score observation (all items 'Moderate': 12 × 2 = 24)."
 Usage: #example
-* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-score-instance)
+* insert MetaProfile(https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/StructureDefinition/mii-pr-pro-observation-whodas12)
 * status = #final
 * category.coding = $hl7-observation-category#survey "Survey"
 * code.coding[+] = $SCT#715823002 "WHODAS (World Health Organization Disability Assessment Schedule) 2.0 score"


### PR DESCRIPTION
## Was
Schließt die Profil-Lücke für die Single-Score-Instrumente PHQ-9, PHQ-15 und WHODAS-12 — analog zum bestehenden Muster A (BDI-II, EQ-5D-5L, PROMIS-29):

- **MII_PR_PRO_Observation_PHQ_9** (0–27, LOINC 44261-6)
- **MII_PR_PRO_Observation_PHQ_15** (0–30, LOINC 70273-8)
- **MII_PR_PRO_Observation_WHODAS_12** (0–48, SNOMED 715823002 + MII-Score-Catalogue; kein LOINC)

Jedes Profil: `Parent MII_PR_PRO_Score_Instance`, value `{score}`-Constraints, `method`, `instantiatesCanonical` → zugehörige ObservationDefinition. Die drei **Beispiel-Observations** wurden auf die neuen Profile gezogen (vorher generisches `Score_Instance`), sodass jedes Profil durch ein Beispiel belegt ist.

## Validierung
`sushi .` → 0 Errors / 0 Warnings. Beispiele: meta.profile korrekt, Werte 27/15/24.

## Nicht enthalten (Folgeschritt)
Multi-Score-Instrumente ohne dedizierte Profile: DASS-21 (6), EORTC QLQ-C30 (16), PRO-CTCAE (2) — größerer Umfang, separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)