### PR TITLE
fix(ci): expand-valuesets EACCES → IG-Build brach ab (chown fsh-generated)

### DIFF
--- a/.github/workflows/ig-publisher.yml
+++ b/.github/workflows/ig-publisher.yml
@@ -80,7 +80,11 @@ jobs:
       # QuestionnaireResponses). Dependency-free node script; mirrors the local
       # pre-commit hook, which CI otherwise skips.
       - name: Expand ValueSets (post-SUSHI)
-        run: node expand-valuesets.js
+        # SUSHI runs in Docker and writes fsh-generated/ as root; take ownership
+        # back so the host-side node process can rewrite the ValueSet files.
+        run: |
+          sudo chown -R "$(id -u):$(id -g)" fsh-generated
+          node expand-valuesets.js
 
       # Run the HL7 FHIR IG Publisher
       - name: Build IG


### PR DESCRIPTION
**Bug (aus #105):** Der `expand-valuesets.js`-Schritt lief host-seitig, aber SUSHI erzeugt `fsh-generated/` im Docker-Container als **root** → `EACCES: permission denied` beim Schreiben der expandierten ValueSets → **Build and Publish IG failte** (u.a. am Release-Commit v2026.5.0, daher kein QA-Report/Pages-Publish).

**Fix:** Vor `node` die Ownership von `fsh-generated` zurückholen:
```yaml
sudo chown -R "$(id -u):$(id -g)" fsh-generated
node expand-valuesets.js
```
Runner hat passwordless sudo + node. Unbricht den IG-Build und lässt die answerValueSet-Expansion (A2-Fix) endlich greifen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)