### PR TITLE
fix(whodas): Beispiel-QR de-Displays (behebt 12 QA-Display-Fehler)

### DIFF
--- a/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
+++ b/fsh-generated/resources/QuestionnaireResponse-mii-exa-pro-whodas12-response-01.json
@@ -16,7 +16,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -28,7 +28,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -40,7 +40,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -52,7 +52,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -64,7 +64,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -76,7 +76,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -88,7 +88,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -100,7 +100,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -112,7 +112,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -124,7 +124,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -136,7 +136,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],
@@ -148,7 +148,7 @@
           "valueCoding": {
             "code": "whodas12-answer-2",
             "system": "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/CodeSystem/mii-cs-pro-whodas-12",
-            "display": "Moderate"
+            "display": "mäßige"
           }
         }
       ],

--- a/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
+++ b/input/fsh/examples/mii-exa-pro-whodas12-response.fsh
@@ -20,51 +20,51 @@ Usage: #example
 
 // Q1 (value: 2)
 * item[+].linkId = "whodas-whodas12-q01"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q2 (value: 2)
 * item[+].linkId = "whodas-whodas12-q02"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q3 (value: 2)
 * item[+].linkId = "whodas-whodas12-q03"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q4 (value: 2)
 * item[+].linkId = "whodas-whodas12-q04"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q5 (value: 2)
 * item[+].linkId = "whodas-whodas12-q05"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q6 (value: 2)
 * item[+].linkId = "whodas-whodas12-q06"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q7 (value: 2)
 * item[+].linkId = "whodas-whodas12-q07"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q8 (value: 2)
 * item[+].linkId = "whodas-whodas12-q08"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q9 (value: 2)
 * item[+].linkId = "whodas-whodas12-q09"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q10 (value: 2)
 * item[+].linkId = "whodas-whodas12-q10"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q11 (value: 2)
 * item[+].linkId = "whodas-whodas12-q11"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // Q12 (value: 2)
 * item[+].linkId = "whodas-whodas12-q12"
-* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "Moderate"
+* item[=].answer.valueCoding = $mii-cs-pro-whodas-12#whodas12-answer-2 "mäßige"
 
 // ===== Simple Sum Score: 12 × 2 = 24 =====
 * item[+].linkId = "whodas-whodas12-score-simple-sum"


### PR DESCRIPTION
Der WHODAS-Beispiel-QR trug EN-Display `"Moderate"` auf den Antwort-Codings; im de-Default-IG-Kontext erwartet der Validator die de-Designation → 12 Display-Mismatch-Fehler im QA. Fix: `"Moderate"` → `"mäßige"` (de-Designation von `whodas12-answer-2`), analog zum bereits gemergten PHQ-15-Fix. sushi 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)