### PR TITLE
release: v2026.5.1 — PHQ-9 linkId-Migrations-ConceptMap

### DIFF
--- a/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/Release-Notes.page.md
+++ b/implementation-guides/MII-PRO-v2026-DE/MIIIGModulPRO/Release-Notes.page.md
@@ -5,9 +5,20 @@ topic: Release-Notes
 
 Diese Seite dokumentiert die Änderungen zwischen den Versionen des MII PRO-Moduls.
 
+**Version: 2026.5.1**
+
+Datum: 2026-07-13 (in Vorbereitung)
+
+Patch-Release auf 2026.5.0.
+
+## Migration & Breaking Changes
+
+- **`BREAKING` (nachgezogen aus 2026.5.0):** Die PHQ-9-Item-linkIds wurden in 2026.5.0 vom Schema `phq-phq9-q01…q10` auf den gemeinsamen PHQ-D-Block-Namespace (`phq-phq2a…i` + `phq-phq9-difficulty`) umgestellt. Bestehende PHQ-9-`QuestionnaireResponse`s mit alten linkIds matchen den Questionnaire ab 2026.5.0 nicht mehr.
+- Added: **ConceptMap `mii-cm-pro-phq-9-linkid-migration`** — bildet die alten PHQ-9-linkIds 1:1 auf die neuen ab (10 Items), zur Migration bestehender Antworten. Die berechneten Items (`phq-phq9-score-total`, `phq-phq9-promis-tscore`) wurden nicht umbenannt.
+
 **Version: 2026.5.0**
 
-Datum: 2026-07-07 (in Vorbereitung)
+Datum: 2026-07-13 (released, Tag `v2026.5.0`, GitHub-Release + Package)
 
 Minor-Release: zwei neue Instrumente (**WHODAS 2.0 12-Item** und **PHQ-15**), Aufbau einer gemeinsamen **PHQ-D-Itembank** (PHQ-9/PHQ-15), einheitliche **MII-Score-Codierung** über alle Score-ObsDefs und eine **CI-Verbesserung** (ValueSet-Expansion), die die answerValueSet-Antwortvalidierung dauerhaft korrigiert.
 

--- a/input/fsh/definitions/phq-9/mii-cm-pro-phq-9-linkid-migration.fsh
+++ b/input/fsh/definitions/phq-9/mii-cm-pro-phq-9-linkid-migration.fsh
@@ -1,0 +1,50 @@
+// PHQ-9 linkId migration: pre-2026.5.0 scheme (phq-phq9-q01…q10) → shared
+// PHQ-D block namespace (phq-phq2a…i + phq-phq9-difficulty) introduced in 2026.5.0.
+// BREAKING between released versions 2026.4.x and 2026.5.0 — this ConceptMap lets
+// consumers migrate existing PHQ-9 QuestionnaireResponse item.linkId values.
+
+Instance: mii-cm-pro-phq-9-linkid-migration
+InstanceOf: ConceptMap
+Title: "MII CM PRO PHQ-9 linkId Migration (2026.4.x → 2026.5.0)"
+Description: "Maps PHQ-9 item linkIds from the pre-2026.5.0 scheme (phq-phq9-q01…q10) to the PHQ-D block namespace (phq-phq2a…i and phq-phq9-difficulty) introduced in 2026.5.0. Apply to existing PHQ-9 QuestionnaireResponses so their item.linkId values match the current Questionnaire. The calculated items phq-phq9-score-total and phq-phq9-promis-tscore were not renamed."
+Usage: #definition
+* insert Version
+* url = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/ConceptMap/mii-cm-pro-phq-9-linkid-migration"
+* status = #active
+* experimental = false
+* sourceCanonical = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-9"
+* targetCanonical = "https://www.medizininformatik-initiative.de/fhir/ext/modul-pro/Questionnaire/mii-qst-pro-phq-9"
+
+* group[+]
+// 9 symptom items: phq-phq9-q0N → phq-phq2X
+* group[=].element[+].code = #phq-phq9-q01
+* group[=].element[=].target.code = #phq-phq2a
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q02
+* group[=].element[=].target.code = #phq-phq2b
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q03
+* group[=].element[=].target.code = #phq-phq2c
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q04
+* group[=].element[=].target.code = #phq-phq2d
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q05
+* group[=].element[=].target.code = #phq-phq2e
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q06
+* group[=].element[=].target.code = #phq-phq2f
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q07
+* group[=].element[=].target.code = #phq-phq2g
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q08
+* group[=].element[=].target.code = #phq-phq2h
+* group[=].element[=].target.equivalence = #equal
+* group[=].element[+].code = #phq-phq9-q09
+* group[=].element[=].target.code = #phq-phq2i
+* group[=].element[=].target.equivalence = #equal
+// functional difficulty item: phq-phq9-q10 → phq-phq9-difficulty
+* group[=].element[+].code = #phq-phq9-q10
+* group[=].element[=].target.code = #phq-phq9-difficulty
+* group[=].element[=].target.equivalence = #equal

--- a/input/fsh/rulesets/version.fsh
+++ b/input/fsh/rulesets/version.fsh
@@ -15,20 +15,20 @@
 
 // For Questionnaire instances (native FHIR R4 element)
 RuleSet: Version
-* version = "2026.5.0"
+* version = "2026.5.1"
 
 // For Profile, CodeSystem, ValueSet, Extension definitions (caret notation)
 RuleSet: PR_CS_VS_Version
-* ^version = "2026.5.0"
+* ^version = "2026.5.1"
 
 // For ObservationDefinition instances (R4 backport of R5 version element)
 // ObservationDefinition lacks native version in R4; added in R5
 // See: https://hl7.org/fhir/extensions/StructureDefinition-artifact-version.html
 RuleSet: ObsDefVersion
 * extension[+].url = "http://hl7.org/fhir/StructureDefinition/artifact-version"
-* extension[=].valueString = "2026.5.0"
+* extension[=].valueString = "2026.5.1"
 
 // For all instances to declare profile conformance with versioned canonical
-// Generates: meta.profile = "{canonical}|2026.5.0"
+// Generates: meta.profile = "{canonical}|2026.5.1"
 RuleSet: MetaProfile(canonical)
-* meta.profile[+] = "{canonical}|2026.5.0"
+* meta.profile[+] = "{canonical}|2026.5.1"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -1,8 +1,19 @@
 Diese Seite dokumentiert die Änderungen zwischen den Versionen des MII PRO-Moduls.
 
+**Version: 2026.5.1**
+
+Datum: 2026-07-13 (in Vorbereitung)
+
+Patch-Release auf 2026.5.0.
+
+## Migration & Breaking Changes
+
+- **`BREAKING` (nachgezogen aus 2026.5.0):** Die PHQ-9-Item-linkIds wurden in 2026.5.0 vom Schema `phq-phq9-q01…q10` auf den gemeinsamen PHQ-D-Block-Namespace (`phq-phq2a…i` + `phq-phq9-difficulty`) umgestellt. Bestehende PHQ-9-`QuestionnaireResponse`s mit alten linkIds matchen den Questionnaire ab 2026.5.0 nicht mehr.
+- Added: **ConceptMap `mii-cm-pro-phq-9-linkid-migration`** — bildet die alten PHQ-9-linkIds 1:1 auf die neuen ab (10 Items: `phq-phq9-q01…q09` → `phq-phq2a…i`, `phq-phq9-q10` → `phq-phq9-difficulty`), zur Migration bestehender Antworten. Die berechneten Items (`phq-phq9-score-total`, `phq-phq9-promis-tscore`) wurden nicht umbenannt.
+
 **Version: 2026.5.0**
 
-Datum: 2026-07-07 (in Vorbereitung)
+Datum: 2026-07-13 (released, Tag `v2026.5.0`, GitHub-Release + Package)
 
 Minor-Release: zwei neue Instrumente (**WHODAS 2.0 12-Item** und **PHQ-15**), Aufbau einer gemeinsamen **PHQ-D-Itembank** (PHQ-9/PHQ-15), einheitliche **MII-Score-Codierung** über alle Score-ObsDefs und eine **CI-Verbesserung** (ValueSet-Expansion), die die answerValueSet-Antwortvalidierung dauerhaft korrigiert.
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -3,7 +3,7 @@ Die vorliegende Spezifikation des Moduls PROs, PROMs und abgeleitete Metriken be
 | Veröffentlichung |   |
 |---------|---|
 | Datum   | 07.07.2026 |
-| Version | 2026.5.0   |
+| Version | 2026.5.1   |
 | Status  | active     |
 | Realm   | DE         |
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "de.medizininformatikinitiative.kerndatensatz.pros",
-  "version": "2026.5.0",
-  "description": "MII PRO Module v2026.5.0 - Neue Instrumente WHODAS 2.0 12-Item (Einschränkungsscore, mit korrekten WHO-Lizenzbedingungen) und PHQ-15 (somatische Symptomlast, PHQ-D); PHQ-9/PHQ-15 auf gemeinsames PHQ-D-Block-LinkId-Schema; MII-Katalog-Codes (code.coding[mii]) auf allen Score-ObsDefs; ValueSet-Expansion im IG-Build (answerValueSet-Validierung). Release Notes: https://simplifier.net/guide/mii-pro-v2026-de/MIIIGModulPRO/Release-Notes",
+  "version": "2026.5.1",
+  "description": "MII PRO Module v2026.5.1 - Patch auf v2026.5.0: PHQ-9 linkId-Migrations-ConceptMap (mii-cm-pro-phq-9-linkid-migration) für den BREAKING linkId-Wechsel. v2026.5.0: Neue Instrumente WHODAS 2.0 12-Item (Einschränkungsscore, mit korrekten WHO-Lizenzbedingungen) und PHQ-15 (somatische Symptomlast, PHQ-D); PHQ-9/PHQ-15 auf gemeinsames PHQ-D-Block-LinkId-Schema; MII-Katalog-Codes (code.coding[mii]) auf allen Score-ObsDefs; ValueSet-Expansion im IG-Build (answerValueSet-Validierung). Release Notes: https://simplifier.net/guide/mii-pro-v2026-de/MIIIGModulPRO/Release-Notes",
   "keywords": [
     "MII",
     "KDS",

--- a/qc/custom.rules.yaml
+++ b/qc/custom.rules.yaml
@@ -21,7 +21,7 @@
   filter: (StructureDefinition or ValueSet or CodeSystem or ConceptMap or StructureMap or NamingSystem or SearchParameter or CapabilityStatement or OperationDefinition or ImplementationGuide).exists()
   # Excluding NamingSystem as they have no version
   status: "Checking if all resources have version filled"
-  predicate: version.exists() and (version in ('2026.0.0-rc.1', '2026.0.0-rc.2', '2026.0.0-rc.3', '2026.0.0-rc.4', '2026.0.0-ballot', '2026.0.0', '2026.0.1', '2026.1.0', '2026.2.0', '2026.3.0', '2026.4.0', '2026.4.1', '2026.5.0'))
+  predicate: version.exists() and (version in ('2026.0.0-rc.1', '2026.0.0-rc.2', '2026.0.0-rc.3', '2026.0.0-rc.4', '2026.0.0-ballot', '2026.0.0', '2026.0.1', '2026.1.0', '2026.2.0', '2026.3.0', '2026.4.0', '2026.4.1', '2026.5.0', '2026.5.1'))
   error-message: "version not filled (correctly)"
   files:
     - /**/*.xml

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -9,7 +9,7 @@ name: MII_IG_PRO
 title: "MII IG PRO"
 description: "Medizininformatik Initiative - Modul PROs, PROMs und abgeleitete Metriken"
 status: active # draft | active | retired | unknown
-version: 2026.5.0
+version: 2026.5.1
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 packageId: de.medizininformatikinitiative.kerndatensatz.pros
 copyrightYear: 2025+


### PR DESCRIPTION
## Release v2026.5.1 (Patch auf v2026.5.0)

### Neu
- **ConceptMap `mii-cm-pro-phq-9-linkid-migration`** — bildet die alten PHQ-9-Item-linkIds 1:1 auf die neuen ab (10 Items: `phq-phq9-q01…q09` → `phq-phq2a…i`, `phq-phq9-q10` → `phq-phq9-difficulty`). Ermöglicht die Migration bestehender PHQ-9-`QuestionnaireResponse`s nach dem **BREAKING** linkId-Wechsel aus 2026.5.0.

### Release-Notes nachgezogen
- **2026.5.0** von „in Vorbereitung" auf **„released, Tag `v2026.5.0`"** gesetzt (GitHub-Release + Package sind live).
- **2026.5.1**-Sektion mit BREAKING-Hinweis + ConceptMap.
- Beide Orte: `input/pagecontent/changes.md` **und** Simplifier-Guide `Release-Notes.page.md`.

### Version-Bump
`2026.5.0` → `2026.5.1` (version.fsh ×5, sushi-config, package.json, qc/custom.rules, index.md). `fsh-generated` regeneriert das CI.

Lokal: `sushi .` → 0 Errors / 0 Warnings; ConceptMap 10 Mappings, Version-Propagation verifiziert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)